### PR TITLE
New Informational Commands

### DIFF
--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -44,7 +44,7 @@ module.exports = class extends Command {
     };
     const allowed = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
 
-    const roleInfos = new this.client.methods.Embed()
+    const roleInfo = new this.client.methods.Embed()
       .setColor(role.hexColor || '#FFF')
       .addField('❯ Name', role.name, true)
       .addField('❯ ID', role.id, true)
@@ -53,7 +53,7 @@ module.exports = class extends Command {
       .addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
       .addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
       .addField('❯ Permissions', allowed);
-    return msg.channel.send('', { embed: roleInfos });
+    return msg.channel.send('', { embed: roleInfo });
 
   }
 

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -3,58 +3,58 @@ const moment = require('moment');
 
 module.exports = class extends Command {
 
-    constructor(...args) {
-        super(...args, {
-            runIn: ['text'],
-            description: 'Get information on a role with an id or a mention.',
-            usage: '<Role:role>',
-        });
-    }
+	constructor(...args) {
+		super(...args, {
+			runIn: ['text'],
+			description: 'Get information on a role with an id or a mention.',
+			usage: '<Role:role>'
+		});
+	}
 
-    async run(msg, [role]) {
-        const perms = {
-            ADMINISTRATOR: 'Administrator',
-            VIEW_AUDIT_LOG: 'View Audit Log',
-            MANAGE_GUILD: 'Manage Server',
-            MANAGE_ROLES: 'Manage Roles',
-            MANAGE_CHANNELS: 'Manage Channels',
-            KICK_MEMBERS: 'Kick Members',
-            BAN_MEMBERS: 'Ban Members',
-            CREATE_INSTANT_INVITE: 'Create Instant Invite',
-            CHANGE_NICKNAME: 'Change Nickname',
-            MANAGE_NICKNAMES: 'Manage Nicknames',
-            MANAGE_EMOJIS: 'Manage Emojis',
-            MANAGE_WEBHOOKS: 'Manage Webhooks',
-            VIEW_CHANNEL: 'Read Text Channels and See Voice Channels',
-            SEND_MESSAGES: 'Send Messages',
-            SEND_TTS_MESSAGES: 'Send TTS Messages',
-            MANAGE_MESSAGES: 'Manage Messages',
-            EMBED_LINKS: 'Embed Links',
-            ATTACH_FILES: 'Attach Files',
-            READ_MESSAGE_HISTORY: 'Read Message History',
-            MENTION_EVERYONE: 'Mention Everyone',
-            USE_EXTERNAL_EMOJIS: 'Use External Emojis',
-            ADD_REACTIONS: 'Add Reactions',
-            CONNECT: 'Connect',
-            SPEAK: 'Speak',
-            MUTE_MEMBERS: 'Mute Members',
-            DEAFEN_MEMBERS: 'Deafen Members',
-            MOVE_MEMBERS: 'Move Members',
-            USE_VAD: 'Use Voice Activity',
-        };
-        const allowed = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
+	async run(msg, [role]) {
+		const perms = {
+			ADMINISTRATOR: 'Administrator',
+			VIEW_AUDIT_LOG: 'View Audit Log',
+			MANAGE_GUILD: 'Manage Server',
+			MANAGE_ROLES: 'Manage Roles',
+			MANAGE_CHANNELS: 'Manage Channels',
+			KICK_MEMBERS: 'Kick Members',
+			BAN_MEMBERS: 'Ban Members',
+			CREATE_INSTANT_INVITE: 'Create Instant Invite',
+			CHANGE_NICKNAME: 'Change Nickname',
+			MANAGE_NICKNAMES: 'Manage Nicknames',
+			MANAGE_EMOJIS: 'Manage Emojis',
+			MANAGE_WEBHOOKS: 'Manage Webhooks',
+			VIEW_CHANNEL: 'Read Text Channels and See Voice Channels',
+			SEND_MESSAGES: 'Send Messages',
+			SEND_TTS_MESSAGES: 'Send TTS Messages',
+			MANAGE_MESSAGES: 'Manage Messages',
+			EMBED_LINKS: 'Embed Links',
+			ATTACH_FILES: 'Attach Files',
+			READ_MESSAGE_HISTORY: 'Read Message History',
+			MENTION_EVERYONE: 'Mention Everyone',
+			USE_EXTERNAL_EMOJIS: 'Use External Emojis',
+			ADD_REACTIONS: 'Add Reactions',
+			CONNECT: 'Connect',
+			SPEAK: 'Speak',
+			MUTE_MEMBERS: 'Mute Members',
+			DEAFEN_MEMBERS: 'Deafen Members',
+			MOVE_MEMBERS: 'Move Members',
+			USE_VAD: 'Use Voice Activity'
+		};
+		/* eslint-disable no-unused-vars */
+		const allPermissions = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
 
-        const roleInfo = new this.client.methods.Embed()
-            .setColor(role.hexColor || '#FFF')
-            .addField('❯ Name', role.name, true)
-            .addField('❯ ID', role.id, true)
-            .addField('❯ Color', role.hexColor || 'None', true)
-            .addField('❯ Creation Date', moment(role.createdAt).format('MMMM Do YYYY'), true)
-            .addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
-            .addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
-            .addField('❯ Permissions', allowed);
-        return msg.channel.send('', { embed: roleInfo });
-
-    }
+		const roleInfo = new this.client.methods.Embed()
+			.setColor(role.hexColor || '#FFF')
+			.addField('❯ Name', role.name, true)
+			.addField('❯ ID', role.id, true)
+			.addField('❯ Color', role.hexColor || 'None', true)
+			.addField('❯ Creation Date', moment(role.createdAt).format('MMMM Do YYYY'), true)
+			.addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
+			.addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
+			.addField('❯ Permissions', allPermissions);
+		return msg.channel.send('', { embed: roleInfo });
+	}
 
 };

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -44,7 +44,7 @@ module.exports = class extends Command {
     };
     const allowed = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
 
-    const roleInfo = new this.client.methods.Embed()
+    const roleInfos = new this.client.methods.Embed()
       .setColor(role.hexColor || '#FFF')
       .addField('❯ Name', role.name, true)
       .addField('❯ ID', role.id, true)
@@ -53,7 +53,7 @@ module.exports = class extends Command {
       .addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
       .addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
       .addField('❯ Permissions', allowed);
-    return msg.channel.send('', { embed: roleInfo });
+    return msg.channel.send('', { embed: roleInfos });
 
   }
 

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -3,58 +3,58 @@ const moment = require('moment');
 
 module.exports = class extends Command {
 
-  constructor(...args) {
-    super(...args, {
-      runIn: ['text'],
-      description: 'Get information on a role with an id or a mention.',
-      usage: '<Role:role>',
-    });
-  }
+    constructor(...args) {
+        super(...args, {
+            runIn: ['text'],
+            description: 'Get information on a role with an id or a mention.',
+            usage: '<Role:role>',
+        });
+    }
 
-  async run(msg, [role]) {
-    const perms = {
-      ADMINISTRATOR: 'Administrator',
-      VIEW_AUDIT_LOG: 'View Audit Log',
-      MANAGE_GUILD: 'Manage Server',
-      MANAGE_ROLES: 'Manage Roles',
-      MANAGE_CHANNELS: 'Manage Channels',
-      KICK_MEMBERS: 'Kick Members',
-      BAN_MEMBERS: 'Ban Members',
-      CREATE_INSTANT_INVITE: 'Create Instant Invite',
-      CHANGE_NICKNAME: 'Change Nickname',
-      MANAGE_NICKNAMES: 'Manage Nicknames',
-      MANAGE_EMOJIS: 'Manage Emojis',
-      MANAGE_WEBHOOKS: 'Manage Webhooks',
-      VIEW_CHANNEL: 'Read Text Channels and See Voice Channels',
-      SEND_MESSAGES: 'Send Messages',
-      SEND_TTS_MESSAGES: 'Send TTS Messages',
-      MANAGE_MESSAGES: 'Manage Messages',
-      EMBED_LINKS: 'Embed Links',
-      ATTACH_FILES: 'Attach Files',
-      READ_MESSAGE_HISTORY: 'Read Message History',
-      MENTION_EVERYONE: 'Mention Everyone',
-      USE_EXTERNAL_EMOJIS: 'Use External Emojis',
-      ADD_REACTIONS: 'Add Reactions',
-      CONNECT: 'Connect',
-      SPEAK: 'Speak',
-      MUTE_MEMBERS: 'Mute Members',
-      DEAFEN_MEMBERS: 'Deafen Members',
-      MOVE_MEMBERS: 'Move Members',
-      USE_VAD: 'Use Voice Activity',
-    };
-    const allowed = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
+    async run(msg, [role]) {
+        const perms = {
+            ADMINISTRATOR: 'Administrator',
+            VIEW_AUDIT_LOG: 'View Audit Log',
+            MANAGE_GUILD: 'Manage Server',
+            MANAGE_ROLES: 'Manage Roles',
+            MANAGE_CHANNELS: 'Manage Channels',
+            KICK_MEMBERS: 'Kick Members',
+            BAN_MEMBERS: 'Ban Members',
+            CREATE_INSTANT_INVITE: 'Create Instant Invite',
+            CHANGE_NICKNAME: 'Change Nickname',
+            MANAGE_NICKNAMES: 'Manage Nicknames',
+            MANAGE_EMOJIS: 'Manage Emojis',
+            MANAGE_WEBHOOKS: 'Manage Webhooks',
+            VIEW_CHANNEL: 'Read Text Channels and See Voice Channels',
+            SEND_MESSAGES: 'Send Messages',
+            SEND_TTS_MESSAGES: 'Send TTS Messages',
+            MANAGE_MESSAGES: 'Manage Messages',
+            EMBED_LINKS: 'Embed Links',
+            ATTACH_FILES: 'Attach Files',
+            READ_MESSAGE_HISTORY: 'Read Message History',
+            MENTION_EVERYONE: 'Mention Everyone',
+            USE_EXTERNAL_EMOJIS: 'Use External Emojis',
+            ADD_REACTIONS: 'Add Reactions',
+            CONNECT: 'Connect',
+            SPEAK: 'Speak',
+            MUTE_MEMBERS: 'Mute Members',
+            DEAFEN_MEMBERS: 'Deafen Members',
+            MOVE_MEMBERS: 'Move Members',
+            USE_VAD: 'Use Voice Activity',
+        };
+        const allowed = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
 
-    const roleInfo = new this.client.methods.Embed()
-      .setColor(role.hexColor || '#FFF')
-      .addField('❯ Name', role.name, true)
-      .addField('❯ ID', role.id, true)
-      .addField('❯ Color', role.hexColor || 'None', true)
-      .addField('❯ Creation Date', moment(role.createdAt).format('MMMM Do YYYY'), true)
-      .addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
-      .addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
-      .addField('❯ Permissions', allowed);
-    return msg.channel.send('', { embed: roleInfo });
+        const roleInfo = new this.client.methods.Embed()
+            .setColor(role.hexColor || '#FFF')
+            .addField('❯ Name', role.name, true)
+            .addField('❯ ID', role.id, true)
+            .addField('❯ Color', role.hexColor || 'None', true)
+            .addField('❯ Creation Date', moment(role.createdAt).format('MMMM Do YYYY'), true)
+            .addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
+            .addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
+            .addField('❯ Permissions', allowed);
+        return msg.channel.send('', { embed: roleInfo });
 
-  }
+    }
 
 };

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -1,0 +1,60 @@
+const { Command } = require('klasa');
+const moment = require('moment');
+
+module.exports = class extends Command {
+
+  constructor(...args) {
+    super(...args, {
+      runIn: ['text'],
+      description: 'Get information on a role with an id or a mention.',
+      usage: '<Role:role>',
+    });
+  }
+
+  async run(msg, [role]) {
+    const perms = {
+      ADMINISTRATOR: 'Administrator',
+      VIEW_AUDIT_LOG: 'View Audit Log',
+      MANAGE_GUILD: 'Manage Server',
+      MANAGE_ROLES: 'Manage Roles',
+      MANAGE_CHANNELS: 'Manage Channels',
+      KICK_MEMBERS: 'Kick Members',
+      BAN_MEMBERS: 'Ban Members',
+      CREATE_INSTANT_INVITE: 'Create Instant Invite',
+      CHANGE_NICKNAME: 'Change Nickname',
+      MANAGE_NICKNAMES: 'Manage Nicknames',
+      MANAGE_EMOJIS: 'Manage Emojis',
+      MANAGE_WEBHOOKS: 'Manage Webhooks',
+      VIEW_CHANNEL: 'Read Text Channels and See Voice Channels',
+      SEND_MESSAGES: 'Send Messages',
+      SEND_TTS_MESSAGES: 'Send TTS Messages',
+      MANAGE_MESSAGES: 'Manage Messages',
+      EMBED_LINKS: 'Embed Links',
+      ATTACH_FILES: 'Attach Files',
+      READ_MESSAGE_HISTORY: 'Read Message History',
+      MENTION_EVERYONE: 'Mention Everyone',
+      USE_EXTERNAL_EMOJIS: 'Use External Emojis',
+      ADD_REACTIONS: 'Add Reactions',
+      CONNECT: 'Connect',
+      SPEAK: 'Speak',
+      MUTE_MEMBERS: 'Mute Members',
+      DEAFEN_MEMBERS: 'Deafen Members',
+      MOVE_MEMBERS: 'Move Members',
+      USE_VAD: 'Use Voice Activity',
+    };
+    const allowed = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
+
+    const roleInfo = new this.client.methods.Embed()
+      .setColor(role.hexColor || '#FFF')
+      .addField('❯ Name', role.name, true)
+      .addField('❯ ID', role.id, true)
+      .addField('❯ Color', role.hexColor || 'None', true)
+      .addField('❯ Creation Date', moment(role.createdAt).format('MMMM Do YYYY'), true)
+      .addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
+      .addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
+      .addField('❯ Permissions', allowed);
+    return msg.channel.send('', { embed: roleInfo });
+
+  }
+
+};

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -43,7 +43,6 @@ module.exports = class extends Command {
 
 	async run(msg, [role]) {
 		const allPermissions = Object.entries(role.permissions.serialize()).filter(([allowed]) => allowed).map(([perm]) => this.perms[perm]).join(', ');
-
 		const roleInfo = new this.client.methods.Embed()
 			.setColor(role.hexColor || '#FFF')
 			.addField('❯ Name', role.name, true)
@@ -53,7 +52,7 @@ module.exports = class extends Command {
 			.addField('❯ Hoisted', role.hoist ? 'Yes' : 'No', true)
 			.addField('❯ Mentionable', role.mentionable ? 'Yes' : 'No', true)
 			.addField('❯ Permissions', allPermissions);
-		return msg.channel.send('', { embed: roleInfo });
+		return msg.sendEmbed(roleInfo);
 	}
 
 };

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -9,10 +9,7 @@ module.exports = class extends Command {
 			description: 'Get information on a role with an id or a mention.',
 			usage: '<Role:role>'
 		});
-	}
-
-	async run(msg, [role]) {
-		const perms = {
+		this.perms = {
 			ADMINISTRATOR: 'Administrator',
 			VIEW_AUDIT_LOG: 'View Audit Log',
 			MANAGE_GUILD: 'Manage Server',
@@ -42,8 +39,10 @@ module.exports = class extends Command {
 			MOVE_MEMBERS: 'Move Members',
 			USE_VAD: 'Use Voice Activity'
 		};
-		/* eslint-disable no-unused-vars */
-		const allPermissions = Object.entries(role.serialize()).filter(([perm, allowed]) => allowed).map(([perm]) => perms[perm]).join(', ');
+	}
+
+	async run(msg, [role]) {
+		const allPermissions = Object.entries(role.permissions.serialize()).filter(([allowed]) => allowed).map(([perm]) => this.perms[perm]).join(', ');
 
 		const roleInfo = new this.client.methods.Embed()
 			.setColor(role.hexColor || '#FFF')

--- a/commands/Tools/server-info.js
+++ b/commands/Tools/server-info.js
@@ -36,7 +36,7 @@ module.exports = class extends Command {
 			.addField('❯ Verification Level', this.verificationLevels[msg.guild.verificationLevel], true)
 			.addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
 			.addField('❯ Members', msg.guild.memberCount, true);
-		return msg.channel.send({ embed: serverInfo });
+		return msg.sendEmbed(serverInfo);
 	}
 
 };

--- a/commands/Tools/server-info.js
+++ b/commands/Tools/server-info.js
@@ -2,43 +2,41 @@ const { Command } = require('klasa');
 const moment = require('moment');
 
 const filterLevels = [
-    'Off',
-    'No Role',
-    'Everyone',
+	'Off',
+	'No Role',
+	'Everyone'
 ];
 const verificationLevels = [
-    'None',
-    'Low',
-    'Medium',
-    '(╯°□°）╯︵ ┻━┻',
-    '┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻',
+	'None',
+	'Low',
+	'Medium',
+	'(╯°□°）╯︵ ┻━┻',
+	'┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻'
 ];
 
 module.exports = class extends Command {
 
-    constructor(...args) {
-        super(...args, {
-            runIn: ['text'],
-            aliases: ['guild'],
-            description: 'Get information on the current server.',
-        });
-    }
+	constructor(...args) {
+		super(...args, {
+			runIn: ['text'],
+			aliases: ['guild'],
+			description: 'Get information on the current server.'
+		});
+	}
 
-    async run(msg) {
-
-        const serverInfo = new this.client.methods.Embed()
-            .setColor(0x00AE86)
-            .setThumbnail(msg.guild.iconURL())
-            .addField('❯ Name', msg.guild.name, true)
-            .addField('❯ ID', msg.guild.id, true)
-            .addField('❯ Creation Date', moment(msg.guild.createdAt).format('MMMM Do YYYY'), true)
-            .addField('❯ Region', msg.guild.region, true)
-            .addField('❯ Explicit Filter', filterLevels[msg.guild.explicitContentFilter], true)
-            .addField('❯ Verification Level', verificationLevels[msg.guild.verificationLevel], true)
-            .addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
-            .addField('❯ Members', msg.guild.memberCount, true);
-        return msg.channel.send({ embed: serverInfo });
-
-    }
+	async run(msg) {
+		const serverInfo = new this.client.methods.Embed()
+			.setColor(0x00AE86)
+			.setThumbnail(msg.guild.iconURL())
+			.addField('❯ Name', msg.guild.name, true)
+			.addField('❯ ID', msg.guild.id, true)
+			.addField('❯ Creation Date', moment(msg.guild.createdAt).format('MMMM Do YYYY'), true)
+			.addField('❯ Region', msg.guild.region, true)
+			.addField('❯ Explicit Filter', filterLevels[msg.guild.explicitContentFilter], true)
+			.addField('❯ Verification Level', verificationLevels[msg.guild.verificationLevel], true)
+			.addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
+			.addField('❯ Members', msg.guild.memberCount, true);
+		return msg.channel.send({ embed: serverInfo });
+	}
 
 };

--- a/commands/Tools/server-info.js
+++ b/commands/Tools/server-info.js
@@ -1,0 +1,44 @@
+const { Command } = require('klasa');
+const moment = require('moment');
+
+const filterLevels = [
+  'Off',
+  'No Role',
+  'Everyone',
+];
+const verificationLevels = [
+  'None',
+  'Low',
+  'Medium',
+  '(╯°□°）╯︵ ┻━┻',
+  '┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻',
+];
+
+module.exports = class extends Command {
+
+  constructor(...args) {
+    super(...args, {
+      runIn: ['text'],
+      aliases: ['guild'],
+      description: 'Get information on the current server.',
+    });
+  }
+
+  async run(msg) {
+
+    const serverInfo = new this.client.methods.Embed()
+      .setColor(0x00AE86)
+      .setThumbnail(msg.guild.iconURL())
+      .addField('❯ Name', msg.guild.name, true)
+      .addField('❯ ID', msg.guild.id, true)
+      .addField('❯ Creation Date', moment(msg.guild.createdAt).format('MMMM Do YYYY'), true)
+      .addField('❯ Region', msg.guild.region, true)
+      .addField('❯ Explicit Filter', filterLevels[msg.guild.explicitContentFilter], true)
+      .addField('❯ Verification Level', verificationLevels[msg.guild.verificationLevel], true)
+      .addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
+      .addField('❯ Members', msg.guild.memberCount, true);
+    return msg.channel.send({ embed: serverInfo });
+
+  }
+
+};

--- a/commands/Tools/server-info.js
+++ b/commands/Tools/server-info.js
@@ -1,19 +1,6 @@
 const { Command } = require('klasa');
 const moment = require('moment');
 
-const filterLevels = [
-	'Off',
-	'No Role',
-	'Everyone'
-];
-const verificationLevels = [
-	'None',
-	'Low',
-	'Medium',
-	'(╯°□°）╯︵ ┻━┻',
-	'┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻'
-];
-
 module.exports = class extends Command {
 
 	constructor(...args) {
@@ -22,6 +9,19 @@ module.exports = class extends Command {
 			aliases: ['guild'],
 			description: 'Get information on the current server.'
 		});
+		this.verificationLevels = [
+			'None',
+			'Low',
+			'Medium',
+			'(╯°□°）╯︵ ┻━┻',
+			'┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻'
+		];
+
+		this.filterLevels = [
+			'Off',
+			'No Role',
+			'Everyone'
+		];
 	}
 
 	async run(msg) {
@@ -32,8 +32,8 @@ module.exports = class extends Command {
 			.addField('❯ ID', msg.guild.id, true)
 			.addField('❯ Creation Date', moment(msg.guild.createdAt).format('MMMM Do YYYY'), true)
 			.addField('❯ Region', msg.guild.region, true)
-			.addField('❯ Explicit Filter', filterLevels[msg.guild.explicitContentFilter], true)
-			.addField('❯ Verification Level', verificationLevels[msg.guild.verificationLevel], true)
+			.addField('❯ Explicit Filter', this.filterLevels[msg.guild.explicitContentFilter], true)
+			.addField('❯ Verification Level', this.verificationLevels[msg.guild.verificationLevel], true)
 			.addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
 			.addField('❯ Members', msg.guild.memberCount, true);
 		return msg.channel.send({ embed: serverInfo });

--- a/commands/Tools/server-info.js
+++ b/commands/Tools/server-info.js
@@ -2,43 +2,43 @@ const { Command } = require('klasa');
 const moment = require('moment');
 
 const filterLevels = [
-  'Off',
-  'No Role',
-  'Everyone',
+    'Off',
+    'No Role',
+    'Everyone',
 ];
 const verificationLevels = [
-  'None',
-  'Low',
-  'Medium',
-  '(╯°□°）╯︵ ┻━┻',
-  '┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻',
+    'None',
+    'Low',
+    'Medium',
+    '(╯°□°）╯︵ ┻━┻',
+    '┻━┻ ﾐヽ(ಠ益ಠ)ノ彡┻━┻',
 ];
 
 module.exports = class extends Command {
 
-  constructor(...args) {
-    super(...args, {
-      runIn: ['text'],
-      aliases: ['guild'],
-      description: 'Get information on the current server.',
-    });
-  }
+    constructor(...args) {
+        super(...args, {
+            runIn: ['text'],
+            aliases: ['guild'],
+            description: 'Get information on the current server.',
+        });
+    }
 
-  async run(msg) {
+    async run(msg) {
 
-    const serverInfo = new this.client.methods.Embed()
-      .setColor(0x00AE86)
-      .setThumbnail(msg.guild.iconURL())
-      .addField('❯ Name', msg.guild.name, true)
-      .addField('❯ ID', msg.guild.id, true)
-      .addField('❯ Creation Date', moment(msg.guild.createdAt).format('MMMM Do YYYY'), true)
-      .addField('❯ Region', msg.guild.region, true)
-      .addField('❯ Explicit Filter', filterLevels[msg.guild.explicitContentFilter], true)
-      .addField('❯ Verification Level', verificationLevels[msg.guild.verificationLevel], true)
-      .addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
-      .addField('❯ Members', msg.guild.memberCount, true);
-    return msg.channel.send({ embed: serverInfo });
+        const serverInfo = new this.client.methods.Embed()
+            .setColor(0x00AE86)
+            .setThumbnail(msg.guild.iconURL())
+            .addField('❯ Name', msg.guild.name, true)
+            .addField('❯ ID', msg.guild.id, true)
+            .addField('❯ Creation Date', moment(msg.guild.createdAt).format('MMMM Do YYYY'), true)
+            .addField('❯ Region', msg.guild.region, true)
+            .addField('❯ Explicit Filter', filterLevels[msg.guild.explicitContentFilter], true)
+            .addField('❯ Verification Level', verificationLevels[msg.guild.verificationLevel], true)
+            .addField('❯ Owner', msg.guild.owner ? msg.guild.owner.user.tag : 'None', true)
+            .addField('❯ Members', msg.guild.memberCount, true);
+        return msg.channel.send({ embed: serverInfo });
 
-  }
+    }
 
 };

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -2,36 +2,35 @@ const { Command } = require('klasa');
 const moment = require('moment');
 
 const statuses = {
-    online: '<:online:313956277808005120> Online',
-    idle: '<:away:313956277220802560> Idle',
-    dnd: '<:dnd:313956276893646850> Do Not Disturb',
-    offline: '<:offline:313956277237710868> Offline',
+	online: '<:online:313956277808005120> Online',
+	idle: '<:away:313956277220802560> Idle',
+	dnd: '<:dnd:313956276893646850> Do Not Disturb',
+	offline: '<:offline:313956277237710868> Offline'
 };
 
 module.exports = class extends Command {
 
-    constructor(...args) {
-        super(...args, {
-            description: 'Get information on a mentioned user.',
-            usage: '[Member:member]',
-        });
-    }
+	constructor(...args) {
+		super(...args, {
+			description: 'Get information on a mentioned user.',
+			usage: '[Member:member]'
+		});
+	}
 
-    async run(msg, [...args]) {
-
-        const member = args[0] || msg.member;
-        const userInfo = new this.client.methods.Embed()
-            .setColor(member.displayHexColor || 0)
-            .setThumbnail(member.user.displayAvatarURL())
-            .addField('❯ Name', member.user.tag, true)
-            .addField('❯ ID', member.id, true)
-            .addField('❯ Discord Join Date', moment(member.user.createdAt).format('MMMM Do YYYY'), true)
-            .addField('❯ Server Join Date', moment(member.joinedTimestamp).format('MMMM Do YYYY'), true)
-            .addField('❯ Status', statuses[member.user.presence.status], true)
-            .addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
-            .addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
-            .addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);
-        return msg.send({ embed: userInfo });
-    }
+	async run(msg, [...args]) {
+		const member = args[0] || msg.member;
+		const userInfo = new this.client.methods.Embed()
+			.setColor(member.displayHexColor || 0)
+			.setThumbnail(member.user.displayAvatarURL())
+			.addField('❯ Name', member.user.tag, true)
+			.addField('❯ ID', member.id, true)
+			.addField('❯ Discord Join Date', moment(member.user.createdAt).format('MMMM Do YYYY'), true)
+			.addField('❯ Server Join Date', moment(member.joinedTimestamp).format('MMMM Do YYYY'), true)
+			.addField('❯ Status', statuses[member.user.presence.status], true)
+			.addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
+			.addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
+			.addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);
+		return msg.send({ embed: userInfo });
+	}
 
 };

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -2,36 +2,36 @@ const { Command } = require('klasa');
 const moment = require('moment');
 
 const statuses = {
-  online: '<:online:313956277808005120> Online',
-  idle: '<:away:313956277220802560> Idle',
-  dnd: '<:dnd:313956276893646850> Do Not Disturb',
-  offline: '<:offline:313956277237710868> Offline',
+    online: '<:online:313956277808005120> Online',
+    idle: '<:away:313956277220802560> Idle',
+    dnd: '<:dnd:313956276893646850> Do Not Disturb',
+    offline: '<:offline:313956277237710868> Offline',
 };
 
 module.exports = class extends Command {
 
-  constructor(...args) {
-    super(...args, {
-      description: 'Get information on a mentioned user.',
-      usage: '[Member:member]',
-    });
-  }
+    constructor(...args) {
+        super(...args, {
+            description: 'Get information on a mentioned user.',
+            usage: '[Member:member]',
+        });
+    }
 
-  async run(msg, [...args]) {
+    async run(msg, [...args]) {
 
-    const member = args[0] || msg.member;
-    const userInfo = new this.client.methods.Embed()
-      .setColor(member.displayHexColor || 0)
-      .setThumbnail(member.user.displayAvatarURL())
-      .addField('❯ Name', member.user.tag, true)
-      .addField('❯ ID', member.id, true)
-      .addField('❯ Discord Join Date', moment(member.user.createdAt).format('MMMM Do YYYY'), true)
-      .addField('❯ Server Join Date', moment(member.joinedTimestamp).format('MMMM Do YYYY'), true)
-      .addField('❯ Status', statuses[member.user.presence.status], true)
-      .addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
-      .addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
-      .addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);
-    return msg.send({ embed: userInfo });
-  }
+        const member = args[0] || msg.member;
+        const userInfo = new this.client.methods.Embed()
+            .setColor(member.displayHexColor || 0)
+            .setThumbnail(member.user.displayAvatarURL())
+            .addField('❯ Name', member.user.tag, true)
+            .addField('❯ ID', member.id, true)
+            .addField('❯ Discord Join Date', moment(member.user.createdAt).format('MMMM Do YYYY'), true)
+            .addField('❯ Server Join Date', moment(member.joinedTimestamp).format('MMMM Do YYYY'), true)
+            .addField('❯ Status', statuses[member.user.presence.status], true)
+            .addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
+            .addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
+            .addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);
+        return msg.send({ embed: userInfo });
+    }
 
 };

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -1,0 +1,37 @@
+const { Command } = require('klasa');
+const moment = require('moment');
+
+const statuses = {
+  online: '<:online:313956277808005120> Online',
+  idle: '<:away:313956277220802560> Idle',
+  dnd: '<:dnd:313956276893646850> Do Not Disturb',
+  offline: '<:offline:313956277237710868> Offline',
+};
+
+module.exports = class extends Command {
+
+  constructor(...args) {
+    super(...args, {
+      description: 'Get information on a mentioned user.',
+      usage: '[Member:member]',
+    });
+  }
+
+  async run(msg, [...args]) {
+
+    const member = args[0] || msg.member;
+    const userInfo = new this.client.methods.Embed()
+      .setColor(member.displayHexColor || 0)
+      .setThumbnail(member.user.displayAvatarURL())
+      .addField('❯ Name', member.user.tag, true)
+      .addField('❯ ID', member.id, true)
+      .addField('❯ Discord Join Date', moment(member.user.createdAt).format('MMMM Do YYYY'), true)
+      .addField('❯ Server Join Date', moment(member.joinedTimestamp).format('MMMM Do YYYY'), true)
+      .addField('❯ Status', statuses[member.user.presence.status], true)
+      .addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
+      .addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
+      .addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);
+    return msg.send({ embed: userInfo });
+  }
+
+};

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -1,13 +1,6 @@
 const { Command } = require('klasa');
 const moment = require('moment');
 
-const statuses = {
-	online: '💚 Online',
-	idle: '💛 Idle',
-	dnd: '💔 Do Not Disturb',
-	offline: '❤ Offline'
-};
-
 module.exports = class extends Command {
 
 	constructor(...args) {
@@ -15,6 +8,12 @@ module.exports = class extends Command {
 			description: 'Get information on a mentioned user.',
 			usage: '[Member:member]'
 		});
+		this.statuses = {
+			online: ':green_heart: Online',
+			idle: ':yellow_heart: Idle',
+			dnd: ':heart: Do Not Disturb',
+			offline: ':broken_heart: Offline'
+		};
 	}
 
 	async run(msg, [...args]) {
@@ -26,7 +25,7 @@ module.exports = class extends Command {
 			.addField('❯ ID', member.id, true)
 			.addField('❯ Discord Join Date', moment(member.user.createdAt).format('MMMM Do YYYY'), true)
 			.addField('❯ Server Join Date', moment(member.joinedTimestamp).format('MMMM Do YYYY'), true)
-			.addField('❯ Status', statuses[member.user.presence.status], true)
+			.addField('❯ Status', this.statuses[member.user.presence.status], true)
 			.addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
 			.addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
 			.addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -16,8 +16,8 @@ module.exports = class extends Command {
 		};
 	}
 
-	async run(msg, [...args]) {
-		const member = args[0] || msg.member;
+	async run(msg, [mentioned]) {
+		const member = mentioned || msg.member;
 		const userInfo = new this.client.methods.Embed()
 			.setColor(member.displayHexColor || 0)
 			.setThumbnail(member.user.displayAvatarURL())

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -2,10 +2,10 @@ const { Command } = require('klasa');
 const moment = require('moment');
 
 const statuses = {
-	online: '<:online:313956277808005120> Online',
-	idle: '<:away:313956277220802560> Idle',
-	dnd: '<:dnd:313956276893646850> Do Not Disturb',
-	offline: '<:offline:313956277237710868> Offline'
+	online: '💚 Online',
+	idle: '💛 Idle',
+	dnd: '💔 Do Not Disturb',
+	offline: '❤ Offline'
 };
 
 module.exports = class extends Command {

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -29,7 +29,7 @@ module.exports = class extends Command {
 			.addField('❯ Playing', member.user.presence.activity ? member.user.presence.activity.name : 'N/A', true)
 			.addField('❯ Highest Role', member.highestRole.name !== '@everyone' ? member.highestRole.name : 'None', true)
 			.addField('❯ Hoist Role', member.hoistRole ? member.hoistRole.name : 'None', true);
-		return msg.send({ embed: userInfo });
+		return msg.sendEmbed(userInfo);
 	}
 
 };


### PR DESCRIPTION
# 10/4/2017 - Adds User, Server and Role Commands

- Adds user-info command which allows a mention or id, or no user at all to see self user.
- Adds server-info command which shows you information about the current guild the command is used in.
- Adds role-info command which shows you information on a role that is specified from an role id or role mention.
