### PR TITLE
Exec command zero-width spaces

### DIFF
--- a/commands/System/exec.js
+++ b/commands/System/exec.js
@@ -15,8 +15,8 @@ module.exports = class extends Command {
 		const result = await this.client.methods.util.exec(code, { timeout: 30000 })
 			.catch(error => ({ stdout: null, stderr: error && error.message ? error.message : error }));
 
-		const output = result.stdout ? `**\`OUTPUT\`**${'`​`​`​prolog'}\n${result.stdout}\n${'`​`​`​'}` : '';
-		const outerr = result.stderr ? `**\`ERROR\`**${'`​`​`​prolog'}\n${result.stderr}\n${'`​`​`​'}` : '';
+		const output = result.stdout ? `**\`OUTPUT\`**${'```prolog'}\n${result.stdout}\n${'```'}` : '';
+		const outerr = result.stderr ? `**\`ERROR\`**${'```prolog'}\n${result.stderr}\n${'```'}` : '';
 
 		return msg.send([output, outerr].join('\n'));
 	}


### PR DESCRIPTION
I removed some zero-width spaces that found their way into the exec command, at some point. It messes up the codeblocks in the output.