### PR TITLE
Update pieces to not use client.methods 

### DIFF
--- a/commands/Configuration/prefix.js
+++ b/commands/Configuration/prefix.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			aliases: ['setPrefix'],
 			cooldown: 5,
 			description: 'Change the command prefix the bot uses in your server.',
-			permLevel: 6,
+			permissionLevel: 6,
 			runIn: ['text'],
 			usage: '[reset|prefix:str{1,10}]'
 		});

--- a/commands/Fun/faceapp.js
+++ b/commands/Fun/faceapp.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			cooldown: 5,
-			botPerms: ['ATTACH_FILES'],
+			requiredPermissions: ['ATTACH_FILES'],
 			description: 'Applies a faceapp filter to an image.',
 			usage: '<smile|smile_2|hot|old|young|female|female_2|male|pan|hitman|makeup|wave|glasses|bangs|hipster|goatee|lion|impression|heisenberg|hollywood>'
 		});

--- a/commands/Misc/echo.js
+++ b/commands/Misc/echo.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			permLevel: 6,
+			permissionLevel: 6,
 			runIn: ['text'],
 
 			description: 'Send a message to a channel through the bot.',

--- a/commands/Misc/fml.js
+++ b/commands/Misc/fml.js
@@ -1,4 +1,5 @@
 const { Command } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 const snekfetch = require('snekfetch');
 const HTMLParser = require('fast-html-parser');
 
@@ -15,7 +16,7 @@ module.exports = class extends Command {
 		const downdoot = root.querySelector('.vote-down');
 		const updoot = root.querySelector('.vote-up');
 
-		const embed = new this.client.methods.Embed()
+		const embed = new MessageEmbed()
 			.setTitle(`Requested by ${msg.author.tag}`)
 			.setAuthor('FML Stories')
 			.setColor(msg.member.displayColor)

--- a/commands/Misc/starboard.js
+++ b/commands/Misc/starboard.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			aliases: ['star'],
-			permLevel: 6,
+			permissionLevel: 6,
 			runIn: ['text'],
 			requiredSettings: ['starboard'],
 

--- a/commands/Moderation/ban.js
+++ b/commands/Moderation/ban.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			permLevel: 6,
+			permissionLevel: 6,
 			requiredPermissions: ['BAN_MEMBERS'],
 			runIn: ['text'],
 

--- a/commands/Moderation/ban.js
+++ b/commands/Moderation/ban.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			permLevel: 6,
-			botPerms: ['BAN_MEMBERS'],
+			requiredPermissions: ['BAN_MEMBERS'],
 			runIn: ['text'],
 
 			description: 'Bans a mentioned user. Currently does not require reason (no mod-log).',

--- a/commands/Moderation/check.js
+++ b/commands/Moderation/check.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			permLevel: 6,
+			permissionLevel: 6,
 			runIn: ['text'],
 			requiredSettings: ['minAccAge'],
 

--- a/commands/Moderation/kick.js
+++ b/commands/Moderation/kick.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			permLevel: 6,
-			botPerms: ['KICK_MEMBERS'],
+			requiredPermissions: ['KICK_MEMBERS'],
 			runIn: ['text'],
 
 			description: 'Kicks a mentioned user. Currently does not require reason (no mod-log).',

--- a/commands/Moderation/kick.js
+++ b/commands/Moderation/kick.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			permLevel: 6,
+			permissionLevel: 6,
 			requiredPermissions: ['KICK_MEMBERS'],
 			runIn: ['text'],
 

--- a/commands/Moderation/softban.js
+++ b/commands/Moderation/softban.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			permLevel: 6,
-			botPerms: ['BAN_MEMBERS'],
+			requiredPermissions: ['BAN_MEMBERS'],
 			runIn: ['text'],
 
 			description: 'Softbans a mentioned user. Currently does not require reason (no mod-log).',

--- a/commands/Moderation/softban.js
+++ b/commands/Moderation/softban.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			permLevel: 6,
+			permissionLevel: 6,
 			requiredPermissions: ['BAN_MEMBERS'],
 			runIn: ['text'],
 

--- a/commands/System/Admin/eval.js
+++ b/commands/System/Admin/eval.js
@@ -10,7 +10,7 @@ module.exports = class extends Command {
 			description: (msg) => msg.language.get('COMMAND_EVAL_DESCRIPTION'),
 			extendedHelp: (msg) => msg.language.get('COMMAND_EVAL_EXTENDED'),
 			guarded: true,
-			permLevel: 10,
+			permissionLevel: 10,
 			usage: '<expression:str>'
 		});
 	}

--- a/commands/System/exec.js
+++ b/commands/System/exec.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			aliases: ['execute'],
 			description: 'Execute commands in the terminal, use with EXTREME CAUTION.',
 			guarded: true,
-			permLevel: 10,
+			permissionLevel: 10,
 			usage: '<expression:string>'
 		});
 	}

--- a/commands/System/prune.js
+++ b/commands/System/prune.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			permLevel: 6,
+			permissionLevel: 6,
 			requiredPermissions: ['MANAGE_MESSAGES'],
 			runIn: ['text'],
 

--- a/commands/System/prune.js
+++ b/commands/System/prune.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			permLevel: 6,
-			botPerms: ['MANAGE_MESSAGES'],
+			requiredPermissions: ['MANAGE_MESSAGES'],
 			runIn: ['text'],
 
 			description: 'Prunes a certain amount of messages w/o filter.',

--- a/commands/Tools/movie.js
+++ b/commands/Tools/movie.js
@@ -1,4 +1,5 @@
 const { Command } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 const snekfetch = require('snekfetch');
 // Create a TMDB account on https://www.themoviedb.org/ (if you haven't yet) and go to https://www.themoviedb.org/settings/api to get your API key.
 const tmdbAPIkey = '';
@@ -21,7 +22,7 @@ module.exports = class extends Command {
 
 		if (!movie) throw `I couldn't find a movie with title **${query}** in page ${page}.`;
 
-		const embed = new this.client.methods.Embed()
+		const embed = new MessageEmbed()
 			.setImage(`https://image.tmdb.org/t/p/original${movie.poster_path}`)
 			.setTitle(`${movie.title} (${page} out of ${request.body.results.length} results)`)
 			.setDescription(movie.overview)

--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -1,5 +1,5 @@
 const { Command, Timestamp } = require('klasa');
-
+const { MessageEmbed } = require('discord.js');
 module.exports = class extends Command {
 
 	constructor(...args) {
@@ -43,7 +43,7 @@ module.exports = class extends Command {
 
 	async run(msg, [role]) {
 		const allPermissions = Object.entries(role.permissions.serialize()).filter(perm => perm[1]).map(([perm]) => this.perms[perm]).join(', ');
-		const roleInfo = new this.client.methods.Embed()
+		const roleInfo = new MessageEmbed()
 			.setColor(role.hexColor || 0xFFFFFF)
 			.addField('❯ Name', role.name, true)
 			.addField('❯ ID', role.id, true)

--- a/commands/Tools/server-info.js
+++ b/commands/Tools/server-info.js
@@ -1,4 +1,5 @@
 const { Command, Timestamp } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 
 module.exports = class extends Command {
 
@@ -25,7 +26,7 @@ module.exports = class extends Command {
 	}
 
 	async run(msg) {
-		const serverInfo = new this.client.methods.Embed()
+		const serverInfo = new MessageEmbed()
 			.setColor(0x00AE86)
 			.setThumbnail(msg.guild.iconURL())
 			.addField('❯ Name', msg.guild.name, true)

--- a/commands/Tools/tvshow.js
+++ b/commands/Tools/tvshow.js
@@ -1,4 +1,5 @@
 const { Command } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 const snekfetch = require('snekfetch');
 // Create a TMDB account on https://www.themoviedb.org/ (if you haven't yet) and go to https://www.themoviedb.org/settings/api to get your API key.
 const tmdbAPIkey = '';
@@ -20,7 +21,7 @@ module.exports = class extends Command {
 		const show = request.body.results[page - 1];
 		if (!show) throw `I couldn't find a TV show with title **${query}** in page ${page}.`;
 
-		const embed = new this.client.methods.Embed()
+		const embed = new MessageEmbed()
 			.setColor('RANDOM')
 			.setImage(`https://image.tmdb.org/t/p/original${show.poster_path}`)
 			.setTitle(`${show.name} (${page} out of ${request.body.results.length} results)`)

--- a/commands/Tools/twitch.js
+++ b/commands/Tools/twitch.js
@@ -1,4 +1,5 @@
 const { Command, Timestamp } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 const snekfetch = require('snekfetch');
 
 /**
@@ -22,7 +23,7 @@ module.exports = class extends Command {
 			.catch(() => { throw 'Unable to find account. Did you spell it correctly?'; });
 
 		const creationDate = this.timestamp.display(body.created_at);
-		const embed = new this.client.methods.Embed()
+		const embed = new MessageEmbed()
 			.setColor(6570406)
 			.setThumbnail(body.logo)
 			.setAuthor(body.display_name, 'https://i.imgur.com/OQwQ8z0.jpg', body.url)

--- a/commands/Tools/user-info.js
+++ b/commands/Tools/user-info.js
@@ -1,4 +1,5 @@
 const { Command, Timestamp } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 
 module.exports = class extends Command {
 
@@ -17,7 +18,7 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [member = msg.member]) {
-		const userInfo = new this.client.methods.Embed()
+		const userInfo = new MessageEmbed()
 			.setColor(member.displayHexColor || 0xFFFFFF)
 			.setThumbnail(member.user.displayAvatarURL())
 			.addField('❯ Name', member.user.tag, true)

--- a/commands/Tools/wikipedia.js
+++ b/commands/Tools/wikipedia.js
@@ -1,4 +1,5 @@
 const { Command } = require('klasa');
+const { MessageEmbed } = require('discord.js');
 const snekfetch = require('snekfetch');
 
 module.exports = class extends Command {
@@ -20,7 +21,7 @@ module.exports = class extends Command {
 				throw "I couldn't find a wikipedia article with that title!";
 			});
 
-		const embed = new this.client.methods.Embed()
+		const embed = new MessageEmbed()
 			.setColor(4886754)
 			.setThumbnail((article.thumbnail && article.thumbnail.source) || 'https://i.imgur.com/fnhlGh5.png')
 			.setURL(article.content_urls.desktop.page)

--- a/providers/nedb.js
+++ b/providers/nedb.js
@@ -1,4 +1,5 @@
 const { Provider } = require('klasa');
+const { Collection } = require('discord.js');
 const { resolve } = require('path');
 const fs = require('fs-nextra');
 
@@ -10,7 +11,7 @@ module.exports = class extends Provider {
 	constructor(...args) {
 		super(...args, { description: 'Allows you to use NeDB functionality throught Klasa' });
 		this.baseDir = resolve(this.client.clientBaseDir, 'bwd', 'provider', 'nedb');
-		this.dataStores = new this.client.methods.Collection();
+		this.dataStores = new Collection();
 	}
 
 	init() {


### PR DESCRIPTION
Due to [**#271**](https://github.com/dirigeants/klasa/pull/271), there has been a breaking change with KlasaClient#methods which this PR resolves. The PR removes KlasaClient#methods completely so we will need to import the utils/methods manually.

This PR should be merged because all pieces currently using `this.client.methods` will break on the latest version of klasa.

Specifications of the PR:  `Semver: patch` and `Priority: High`