### PR TITLE
Updated all providers for SGv2.2.0

### DIFF
--- a/providers/firestore.js
+++ b/providers/firestore.js
@@ -1,0 +1,172 @@
+/*
+	1. Go to https://firebase.google.com/
+	2. Login/Signup
+	3. Go to Console
+	4. Create new project
+	5. Go to the database section
+	6. Select Firestore. NOTE- Don't select Real time database
+	7. Then in the LHS of the page, finda settings icon next to Project Overview, select Project settings.
+	8. Go to service accounts
+	9. Click Generate new private key, which will download a json file.
+	10. Copy the databaseURL from the same page.
+	11. Import the json, where ever you are initializing the client.
+	12. Pass this to the constructor, providers: { default: 'firestore', firestore: { credentials: variable_name_for_json, databaseURL: 'databaseURL from the service account page.'}}
+	13. Download the `firebase-admin` module.
+*/
+
+const { Provider } = require('klasa');
+const firebase = require('firebase-admin');
+const { FieldValue } = firebase;
+
+module.exports = class extends Provider {
+
+	constructor(...args) {
+		super(...args);
+		this.db = null;
+	}
+	/**
+	 * Initiaizes the firestore
+	 * @private
+	 */
+	async init() {
+		await firebase.initializeApp({
+			credential: firebase.credential.cert(this.client.options.providers.firestore.credentials),
+			databaseURL: this.client.options.providers.firestore.databaseURL
+		});
+
+		this.db = firebase.firestore();
+	}
+	/**
+	 *Checks if the table/collection exists
+	 * @param {string} table The name of the table/collection to be checked for existance
+	 * @returns {Promise<boolean>}
+	 */
+	hasTable(table) {
+		return this.db.collection(table).get().then(col => !!col.size);
+	}
+
+	/**
+	 * This method is a dummy method, as new tables/collections are automatically created by firestore when needed.
+	 * @param {string} table Name of the collection to create.
+	 * @returns {Promise<Collection>}
+	 */
+	createTable(table) {
+		return this.db.collection(table);
+	}
+
+	/**
+	 * Returns all the documents of a collection
+	 * @param {string} table Name of the collection, for which all values is to be returned
+	 * @returns {Promise<Array>}
+	 */
+	getAll(table) {
+		return this.db.collection(table).get().then(snaps => snaps.docs.map(snap => snap.data()));
+	}
+	/**
+	 * Returns all the Keys/Docs of a collection/tanle.
+	 * @param {string} table Name of the collection/table for which all Keys/Docs is to be returned.
+	 * @returns {Promise<Array>}
+	 */
+	getKeys(table) {
+		return this.db.collection(table).get().then(snaps => snaps.docs.map(snap => snap.id));
+	}
+	/**
+	 * Returns a particular Document from the table/Collection.
+	 * @param {string} table Name of the collection/Table to get the value from
+	 * @param {string} id Name of the Document/Key to be returned
+	 * @returns {Promise<Any>}
+	 */
+	get(table, id) {
+		return this.db.collection(table).doc(id).get();
+	}
+
+	/**
+	 * Checks if a collection has a particular Document/Key
+	 * @param {string} table Name of the collection/Table
+	 * @param {string} id Name of the Document/Key
+	 * @returns {Promise<boolean>}
+	 */
+	has(table, id) {
+		return this.db.collection(table).doc(id).get().then(data => data.exists);
+	}
+
+	/**
+	 * Creates a new Document/Field in a collection.
+	 * @param {string} table Name of the collection/table
+	 * @param {string} id Name of they Docment/Key
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the object you want to insert in the table.
+	 * @returns {Promise<DocumentObject>}
+	 */
+	create(table, id, doc = {}) {
+		return this.db.collection(table).doc(id).set(this.parseUpdateInput(doc));
+	}
+
+	/**
+	 * Updates the values of a Document/Field
+	 * @param {string} table Name of the Collection that contains the Document
+	 * @param {string} id  Name of the Document/field
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the object you want to insert in the table.
+	 * @returns {Promise<WriteResult>}
+	 */
+	update(table, id, doc) {
+		return this.db.collection(table).doc(id).update(this.parseUpdateInput(doc));
+	}
+
+	/**
+	 * Deleted a particular Document/Field from the Collection/Table
+	 * @param {string} table Name of the collection/table
+	 * @param {string} id Name of the Document/Key to delete
+	 * @returns {Promise<WriteResult>}
+	 */
+	async delete(table, id) {
+		return await this.db.collection(table).doc(id).delete();
+	}
+	/**
+	 * Replaces a Document with a new Document specified by the user *
+	 * @param {string} table Name of the Collection
+	 * @param {Object} id The Filter used to select the document to update
+	 * @param {Object} [doc={}] The Document that replaces the matching document
+	 * @returns {Promise}
+	 */
+	replace(...args) {
+		return this.create(...args);
+	}
+
+	/**
+	 * Update or insert a new value to all entries
+	 * @param {string} table Name of the Collectiom
+	 * @param {string} path The Field to be updated in al the Documents
+	 * @param {*} newValue The value to to updated in all the Documents
+	 */
+	async updateValue(table, path, newValue) {
+		const keys = await this.getKeys(table);
+
+		if (typeof path === 'object' && typeof newValue === 'undefined') {
+			await Promise.all(keys.map(doc => this.update(table, doc, path)));
+		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
+			await Promise.all(keys.map(doc => this.update(table, doc, { path: newValue })));
+		} else {
+			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
+		}
+	}
+
+	/**
+	 * Remove a value or object from all entries.
+	 * @param {string} table Name of the Collection
+	 * @param {string} path The Field to be updated in al the Documents
+	 * @param {*} newValue The value to to updated in all the Documents
+	 */
+	async removeValue(table, path) {
+		const keys = await this.getKeys(table);
+		if (typeof path === 'object' && typeof newValue === 'undefined') {
+			for (const key of Object.keys(path)) path[key] = FieldValue.deleteValue();
+			await Promise.all(keys.map(doc => this.update(table, doc, path)));
+		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
+			await Promise.all(keys.map(doc => this.update(table, doc, { path: FieldValue.deleteValue() })));
+		} else {
+			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
+		}
+	}
+
+};
+

--- a/providers/firestore.js
+++ b/providers/firestore.js
@@ -16,6 +16,7 @@
 
 const { Provider } = require('klasa');
 const firebase = require('firebase-admin');
+
 const { FieldValue } = firebase;
 
 module.exports = class extends Provider {
@@ -24,10 +25,6 @@ module.exports = class extends Provider {
 		super(...args);
 		this.db = null;
 	}
-	/**
-	 * Initiaizes the firestore
-	 * @private
-	 */
 	async init() {
 		await firebase.initializeApp({
 			credential: firebase.credential.cert(this.client.options.providers.firestore.credentials),
@@ -36,128 +33,53 @@ module.exports = class extends Provider {
 
 		this.db = firebase.firestore();
 	}
-	/**
-	 *Checks if the table/collection exists
-	 * @param {string} table The name of the table/collection to be checked for existance
-	 * @returns {Promise<boolean>}
-	 */
+
 	hasTable(table) {
-		return this.db.collection(table).get().then(col => !!col.size);
+		return this.db.collection(table).get().then(col => Boolean(col.size));
 	}
 
-	/**
-	 * This method is a dummy method, as new tables/collections are automatically created by firestore when needed.
-	 * @param {string} table Name of the collection to create.
-	 * @returns {Promise<Collection>}
-	 */
 	createTable(table) {
 		return this.db.collection(table);
 	}
 
-	/**
-	 * Returns all the documents of a collection
-	 * @param {string} table Name of the collection, for which all values is to be returned
-	 * @returns {Promise<Array>}
-	 */
-	getAll(table) {
-		return this.db.collection(table).get().then(snaps => snaps.docs.map(snap => snap.data()));
-	}
-	/**
-	 * Returns all the Keys/Docs of a collection/tanle.
-	 * @param {string} table Name of the collection/table for which all Keys/Docs is to be returned.
-	 * @returns {Promise<Array>}
-	 */
 	getKeys(table) {
 		return this.db.collection(table).get().then(snaps => snaps.docs.map(snap => snap.id));
 	}
-	/**
-	 * Returns a particular Document from the table/Collection.
-	 * @param {string} table Name of the collection/Table to get the value from
-	 * @param {string} id Name of the Document/Key to be returned
-	 * @returns {Promise<Any>}
-	 */
+
 	get(table, id) {
-		return this.db.collection(table).doc(id).get();
+		return this.db.collection(table).doc(id).get().then(snap => this.packData(snap.data(), snap.id));
 	}
 
-	/**
-	 * Checks if a collection has a particular Document/Key
-	 * @param {string} table Name of the collection/Table
-	 * @param {string} id Name of the Document/Key
-	 * @returns {Promise<boolean>}
-	 */
 	has(table, id) {
 		return this.db.collection(table).doc(id).get().then(data => data.exists);
 	}
 
-	/**
-	 * Creates a new Document/Field in a collection.
-	 * @param {string} table Name of the collection/table
-	 * @param {string} id Name of they Docment/Key
-	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the object you want to insert in the table.
-	 * @returns {Promise<DocumentObject>}
-	 */
 	create(table, id, doc = {}) {
 		return this.db.collection(table).doc(id).set(this.parseUpdateInput(doc));
 	}
 
-	/**
-	 * Updates the values of a Document/Field
-	 * @param {string} table Name of the Collection that contains the Document
-	 * @param {string} id  Name of the Document/field
-	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the object you want to insert in the table.
-	 * @returns {Promise<WriteResult>}
-	 */
 	update(table, id, doc) {
 		return this.db.collection(table).doc(id).update(this.parseUpdateInput(doc));
 	}
 
-	/**
-	 * Deleted a particular Document/Field from the Collection/Table
-	 * @param {string} table Name of the collection/table
-	 * @param {string} id Name of the Document/Key to delete
-	 * @returns {Promise<WriteResult>}
-	 */
-	async delete(table, id) {
-		return await this.db.collection(table).doc(id).delete();
+	delete(table, id) {
+		return this.db.collection(table).doc(id).delete();
 	}
-	/**
-	 * Replaces a Document with a new Document specified by the user *
-	 * @param {string} table Name of the Collection
-	 * @param {Object} id The Filter used to select the document to update
-	 * @param {Object} [doc={}] The Document that replaces the matching document
-	 * @returns {Promise}
-	 */
+
 	replace(...args) {
 		return this.create(...args);
 	}
 
-	/**
-	 * Update or insert a new value to all entries
-	 * @param {string} table Name of the Collectiom
-	 * @param {string} path The Field to be updated in al the Documents
-	 * @param {*} newValue The value to to updated in all the Documents
-	 */
-	async updateValue(table, path, newValue) {
-		const keys = await this.getKeys(table);
+	async getAll(table, filter = []) {
+		const data = await this.db.collection(table).get()
+			.then(snaps => snaps.docs.map(snap => this.packData(snap.data(), snap.id)));
 
-		if (typeof path === 'object' && typeof newValue === 'undefined') {
-			await Promise.all(keys.map(doc => this.update(table, doc, path)));
-		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
-			await Promise.all(keys.map(doc => this.update(table, doc, { path: newValue })));
-		} else {
-			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
-		}
+		return filter.length ? data.filter(nodes => filter.includes(nodes.id)) : data;
 	}
 
-	/**
-	 * Remove a value or object from all entries.
-	 * @param {string} table Name of the Collection
-	 * @param {string} path The Field to be updated in al the Documents
-	 * @param {*} newValue The value to to updated in all the Documents
-	 */
 	async removeValue(table, path) {
 		const keys = await this.getKeys(table);
+
 		if (typeof path === 'object' && typeof newValue === 'undefined') {
 			for (const key of Object.keys(path)) path[key] = FieldValue.deleteValue();
 			await Promise.all(keys.map(doc => this.update(table, doc, path)));
@@ -166,6 +88,13 @@ module.exports = class extends Provider {
 		} else {
 			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
 		}
+	}
+
+	packData(data, id) {
+		return {
+			...data,
+			id
+		};
 	}
 
 };

--- a/providers/level.js
+++ b/providers/level.js
@@ -1,8 +1,8 @@
 const { Provider, util: { mergeObjects } } = require('klasa');
+const { Collection } = require('discord.js');
 const { resolve } = require('path');
 const fs = require('fs-nextra');
 const Level = require('native-level-promise');
-const Collection = require('djs-collection');
 
 module.exports = class extends Provider {
 
@@ -47,12 +47,15 @@ module.exports = class extends Provider {
 		if (!db) return Promise.reject(new Error(`The table ${table} does not exist.`));
 		return new Promise((res) => {
 			const output = [];
-			db.createReadStream()
+			const stream = db.createReadStream()
 				.on('data', filter.length ? (data) => {
 					data = JSON.parse(data);
 					if (filter.includes(data.id)) output.push(data);
 				} : (data) => output.push(JSON.parse(data.value)))
-				.on('end', res.bind(null, output));
+				.once('end', () => {
+					stream.removeAllListeners();
+					res(output);
+				});
 		});
 	}
 
@@ -61,9 +64,12 @@ module.exports = class extends Provider {
 		if (!db) return Promise.reject(new Error(`The table ${table} does not exist.`));
 		return new Promise((res) => {
 			const output = [];
-			db.keyStream()
+			const stream = db.keyStream()
 				.on('data', key => output.push(key))
-				.on('end', res.bind(null, output));
+				.on('end', () => {
+					stream.removeAllListeners();
+					res(output);
+				});
 		});
 	}
 

--- a/providers/level.js
+++ b/providers/level.js
@@ -19,10 +19,6 @@ module.exports = class extends Provider {
 		for (const db of this.tables.values()) db.close();
 	}
 
-	/**
-	 * Inits the database
-	 * @private
-	 */
 	async init() {
 		await fs.ensureDir(this.baseDir);
 		const files = await fs.readdir(this.baseDir);
@@ -31,29 +27,14 @@ module.exports = class extends Provider {
 
 	/* Table methods */
 
-	/**
-	 * Checks if a directory exists.
-	 * @param {string} table The name of the table you want to check.
-	 * @returns {Promise<boolean>}
-	 */
 	hasTable(table) {
 		return this.tables.has(table);
 	}
 
-	/**
-	 * Creates a new directory.
-	 * @param {string} table The name for the new directory.
-	 * @returns {Promise<void>}
-	 */
 	createTable(table) {
 		return this.tables.set(table, new Level(resolve(this.baseDir, table)));
 	}
 
-	/**
-	 * Recursively deletes a directory.
-	 * @param {string} table The directory's name to delete.
-	 * @returns {Promise<void>}
-	 */
 	deleteTable(table) {
 		if (this.tables.has(table)) return this.tables.get(table).destroy();
 		return Promise.resolve();
@@ -61,27 +42,20 @@ module.exports = class extends Provider {
 
 	/* Document methods */
 
-	/**
-	 * Get all documents from a directory.
-	 * @param {string} table The name of the directory to fetch from.
-	 * @returns {Promise<Object[]>}
-	 */
-	getAll(table) {
+	getAll(table, filter = []) {
 		const db = this.tables.get(table);
 		if (!db) return Promise.reject(new Error(`The table ${table} does not exist.`));
 		return new Promise((res) => {
 			const output = [];
 			db.createReadStream()
-				.on('data', (data) => output.push(JSON.parse(data.value)))
+				.on('data', filter.length ? (data) => {
+					data = JSON.parse(data);
+					if (filter.includes(data.id)) output.push(data);
+				} : (data) => output.push(JSON.parse(data.value)))
 				.on('end', res.bind(null, output));
 		});
 	}
 
-	/**
-	 * Get all document names from a directory.
-	 * @param {string} table The name of the directory to fetch from.
-	 * @returns {Promise<string[]>}
-	 */
 	getKeys(table) {
 		const db = this.tables.get(table);
 		if (!db) return Promise.reject(new Error(`The table ${table} does not exist.`));
@@ -93,123 +67,38 @@ module.exports = class extends Provider {
 		});
 	}
 
-	/**
-	 * Get a document from a directory.
-	 * @param {string} table The name of the directory.
-	 * @param {string} document The document name.
-	 * @returns {Promise<?Object>}
-	 */
 	get(table, document) {
-		return this.tables.get(table).get(document)
-			.then(JSON.parse)
-			.catch(() => null);
+		return this.tables.get(table).get(document).then(JSON.parse).catch(() => null);
 	}
 
-	/**
-	 * Check if the document exists.
-	 * @param {string} table The name of the directory.
-	 * @param {string} document The document name.
-	 * @returns {Promise<boolean>}
-	 */
 	has(table, document) {
-		return this.tables.get(table).has(document).then(Boolean);
+		return this.tables.get(table).has(document);
 	}
 
-	/**
-	 * Update or insert a new value to all entries.
-	 * @param {string} table The name of the directory.
-	 * @param {string} path The key's path to update.
-	 * @param {*} newValue The new value for the key.
-	 */
-	async updateValue(table, path, newValue) {
-		const route = path.split('.');
-		const values = await this.getAll(table);
-		await Promise.all(values.map(object => this._updateValue(table, route, object, newValue)));
+	create(table, document, data = {}) {
+		return this.tables.get(table).put(document, JSON.stringify(mergeObjects(this.parseUpdateInput(data), { id: document })));
 	}
 
-	/**
-	 * Remove a value or object from all entries.
-	 * @param {string} table The name of the directory.
-	 * @param {string} [path=false] The key's path to update.
-	 */
+	update(table, document, data) {
+		return this.get(table, document)
+			.then(existent => this.create(table, document, mergeObjects(existent || { id: document }, this.parseUpdateInput(data))));
+	}
+
+	replace(table, document, data) {
+		return this.create(table, document, data);
+	}
+
+	delete(table, document) {
+		return this.get(table, document)
+			.then(db => db.delete(document));
+	}
+
 	async removeValue(table, path) {
 		const route = path.split('.');
 		const values = await this.getAll(table);
 		await Promise.all(values.map(object => this._removeValue(table, route, object)));
 	}
 
-	/**
-	 * Insert a new document into a directory.
-	 * @param {string} table The name of the directory.
-	 * @param {string} document The document name.
-	 * @param {Object} [data={}] The object with all properties you want to insert into the document.
-	 * @returns {Promise<void>}
-	 */
-	create(table, document, data = {}) {
-		return this.tables.get(table).put(document, JSON.stringify(mergeObjects(this.parseUpdateInput(data), { id: document })));
-	}
-
-	/**
-	 * Update a document from a directory.
-	 * @param {string} table The name of the directory.
-	 * @param {string} document The document name.
-	 * @param {Object} data The object with all the properties you want to update.
-	 * @returns {Promise<void>}
-	 */
-	async update(table, document, data) {
-		const existent = await this.get(table, document) || { id: document };
-		return this.create(table, document, mergeObjects(existent, this.parseUpdateInput(data)));
-	}
-
-	/**
-	 * Replace all the data from a document.
-	 * @param {string} table The name of the directory.
-	 * @param {string} document The document name.
-	 * @param {Object} data The new data for the document.
-	 * @returns {Promise<void>}
-	 */
-	replace(table, document, data) {
-		return this.create(table, document, data);
-	}
-
-	/**
-	 * Delete a document from the table.
-	 * @param {string} table The name of the directory.
-	 * @param {string} document The document name.
-	 * @returns {Promise<void>}
-	 */
-	delete(table, document) {
-		return this.get(table, document)
-			.then(db => db.delete(document));
-	}
-
-	/**
-	 * Update or insert a new value to a specified entry.
-	 * @param {string} table The name of the directory.
-	 * @param {string[]} route An array with the path to update.
-	 * @param {Object} object The entry to update.
-	 * @param {*} newValue The new value for the key.
-	 * @returns {Promise<void>}
-	 * @private
-	 */
-	_updateValue(table, route, object, newValue) {
-		let value = object;
-		for (let j = 0; j < route.length - 1; j++) {
-			if (typeof value[route[j]] === 'undefined') value[route[j]] = { [route[j + 1]]: {} };
-			value = value[route[j]];
-		}
-		value[route[route.length - 1]] = newValue;
-		return this.replace(table, object.id, object);
-	}
-
-	/**
-	 * Remove a value from a specified entry.
-	 * @param {string} table The name of the directory.
-	 * @param {string[]} route An array with the path to update.
-	 * @param {Object} object The entry to update.
-	 * @returns {Promise<void>}
-	 * @private
-	 */
 	_removeValue(table, route, object) {
 		let value = object;
 		for (let j = 0; j < route.length - 1; j++) value = value[route[j]] || {};

--- a/providers/level.js
+++ b/providers/level.js
@@ -32,28 +32,28 @@ module.exports = class extends Provider {
 	/* Table methods */
 
 	/**
-     * Checks if a directory exists.
-     * @param {string} table The name of the table you want to check.
-     * @returns {Promise<boolean>}
-     */
+	 * Checks if a directory exists.
+	 * @param {string} table The name of the table you want to check.
+	 * @returns {Promise<boolean>}
+	 */
 	hasTable(table) {
 		return this.tables.has(table);
 	}
 
 	/**
-     * Creates a new directory.
-     * @param {string} table The name for the new directory.
-     * @returns {Promise<void>}
-     */
+	 * Creates a new directory.
+	 * @param {string} table The name for the new directory.
+	 * @returns {Promise<void>}
+	 */
 	createTable(table) {
 		return this.tables.set(table, new Level(resolve(this.baseDir, table)));
 	}
 
 	/**
-     * Recursively deletes a directory.
-     * @param {string} table The directory's name to delete.
-     * @returns {Promise<void>}
-     */
+	 * Recursively deletes a directory.
+	 * @param {string} table The directory's name to delete.
+	 * @returns {Promise<void>}
+	 */
 	deleteTable(table) {
 		if (this.tables.has(table)) return this.tables.get(table).destroy();
 		return Promise.resolve();
@@ -62,10 +62,10 @@ module.exports = class extends Provider {
 	/* Document methods */
 
 	/**
-     * Get all documents from a directory.
-     * @param {string} table The name of the directory to fetch from.
-     * @returns {Promise<Object[]>}
-     */
+	 * Get all documents from a directory.
+	 * @param {string} table The name of the directory to fetch from.
+	 * @returns {Promise<Object[]>}
+	 */
 	getAll(table) {
 		const db = this.tables.get(table);
 		if (!db) return Promise.reject(new Error(`The table ${table} does not exist.`));
@@ -94,11 +94,11 @@ module.exports = class extends Provider {
 	}
 
 	/**
-     * Get a document from a directory.
-     * @param {string} table The name of the directory.
-     * @param {string} document The document name.
-     * @returns {Promise<?Object>}
-     */
+	 * Get a document from a directory.
+	 * @param {string} table The name of the directory.
+	 * @param {string} document The document name.
+	 * @returns {Promise<?Object>}
+	 */
 	get(table, document) {
 		return this.tables.get(table).get(document)
 			.then(JSON.parse)
@@ -106,11 +106,11 @@ module.exports = class extends Provider {
 	}
 
 	/**
-     * Check if the document exists.
-     * @param {string} table The name of the directory.
-     * @param {string} document The document name.
-     * @returns {Promise<boolean>}
-     */
+	 * Check if the document exists.
+	 * @param {string} table The name of the directory.
+	 * @param {string} document The document name.
+	 * @returns {Promise<boolean>}
+	 */
 	has(table, document) {
 		return this.tables.get(table).has(document).then(Boolean);
 	}
@@ -139,45 +139,45 @@ module.exports = class extends Provider {
 	}
 
 	/**
-     * Insert a new document into a directory.
-     * @param {string} table The name of the directory.
-     * @param {string} document The document name.
-     * @param {Object} [data={}] The object with all properties you want to insert into the document.
-     * @returns {Promise<void>}
-     */
+	 * Insert a new document into a directory.
+	 * @param {string} table The name of the directory.
+	 * @param {string} document The document name.
+	 * @param {Object} [data={}] The object with all properties you want to insert into the document.
+	 * @returns {Promise<void>}
+	 */
 	create(table, document, data = {}) {
 		return this.tables.get(table).put(document, JSON.stringify(mergeObjects(this.parseUpdateInput(data), { id: document })));
 	}
 
 	/**
-     * Update a document from a directory.
-     * @param {string} table The name of the directory.
-     * @param {string} document The document name.
-     * @param {Object} data The object with all the properties you want to update.
-     * @returns {Promise<void>}
-     */
+	 * Update a document from a directory.
+	 * @param {string} table The name of the directory.
+	 * @param {string} document The document name.
+	 * @param {Object} data The object with all the properties you want to update.
+	 * @returns {Promise<void>}
+	 */
 	async update(table, document, data) {
 		const existent = await this.get(table, document) || { id: document };
 		return this.create(table, document, mergeObjects(existent, this.parseUpdateInput(data)));
 	}
 
 	/**
-     * Replace all the data from a document.
-     * @param {string} table The name of the directory.
-     * @param {string} document The document name.
-     * @param {Object} data The new data for the document.
-     * @returns {Promise<void>}
-     */
+	 * Replace all the data from a document.
+	 * @param {string} table The name of the directory.
+	 * @param {string} document The document name.
+	 * @param {Object} data The new data for the document.
+	 * @returns {Promise<void>}
+	 */
 	replace(table, document, data) {
 		return this.create(table, document, data);
 	}
 
 	/**
-     * Delete a document from the table.
-     * @param {string} table The name of the directory.
-     * @param {string} document The document name.
-     * @returns {Promise<void>}
-     */
+	 * Delete a document from the table.
+	 * @param {string} table The name of the directory.
+	 * @param {string} document The document name.
+	 * @returns {Promise<void>}
+	 */
 	delete(table, document) {
 		return this.get(table, document)
 			.then(db => db.delete(document));

--- a/providers/level.js
+++ b/providers/level.js
@@ -66,7 +66,7 @@ module.exports = class extends Provider {
 			const output = [];
 			const stream = db.keyStream()
 				.on('data', key => output.push(key))
-				.on('end', () => {
+				.once('end', () => {
 					stream.removeAllListeners();
 					res(output);
 				});

--- a/providers/level.js
+++ b/providers/level.js
@@ -55,7 +55,7 @@ module.exports = class extends Provider {
      * @returns {Promise<void>}
      */
 	deleteTable(table) {
-		if (this.tables.has(table)) this.tables.get(table).destroy();
+		if (this.tables.has(table)) return this.tables.get(table).destroy();
 		return Promise.resolve();
 	}
 

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -49,10 +49,6 @@ module.exports = class extends Provider {
 		return this.db.createCollection(table);
 	}
 
-	createCollection(...args) {
-		return this.createTable(...args);
-	}
-
 	/**
 	 * Drops a collection within a DB.
 	 * @param {string} table Name of the collection to drop.
@@ -62,10 +58,6 @@ module.exports = class extends Provider {
 		return this.db.dropCollection(table);
 	}
 
-	dropCollection(table) {
-		return this.deleteTable(table);
-	}
-
 	/* Document methods */
 
 	/**
@@ -73,7 +65,8 @@ module.exports = class extends Provider {
 	 * @param {string} table Name of the Collection
 	 * @returns {Promise<Array>}
 	 */
-	getAll(table) {
+	getAll(table, filter = []) {
+		if (filter.length) return this.db.collection(table).find({ id: { $in: filter } }, { _id: 0 }).toArray();
 		return this.db.collection(table).find({}, { _id: 0 }).toArray();
 	}
 
@@ -112,42 +105,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object>}
 	 */
 	getRandom(table) {
-		return this.getKeys(table).then(results => this.get(table, results[Math.floor(Math.random() * results.length)].id));
-	}
-
-	/**
-	 * Update or insert a new value to all entries.
-	 * @param {string} table The name of the table.
-	 * @param {string} path The object to remove or a path to update.
-	 * @param {*} newValue The new value for the key.
-	 * @returns {Promise<Object>}
-	 * @example
-	 * // Editing a single value
-	 * // You can edit a single value in a very similar way to Gateway#updateOne.
-	 * updateValue('339942739275677727', 'channels.modlogs', '340713281972862976');
-	 *
-	 * // However, you can also update it by passing an object.
-	 * updateValue('339942739275677727', { channels: { modlogs: '340713281972862976' } });
-	 *
-	 * // Editing multiple values
-	 * // As MongoDB#update can also work very similar to Gateway#updateMany, it also accepts an entire object with multiple values.
-	 * updateValue('339942739275677727', { prefix: 'k!', roles: { administrator: '339959033937264641' } });
-	 */
-	async updateValue(table, path, newValue) {
-		// { channels: { modlog: '340713281972862976' } } | undefined
-		if (typeof path === 'object' && typeof newValue === 'undefined') {
-			return this.db.collection(table).update({}, { $set: path }, { multi: true });
-		}
-		// 'channels.modlog' | '340713281972862976'
-		if (typeof path === 'string' && typeof newValue !== 'undefined') {
-			const route = path.split('.');
-			const object = {};
-			let ref = object;
-			for (let i = 0; i < route.length - 1; i++) ref = ref[route[i]] = {};
-			ref[route[route.length - 1]] = newValue;
-			return this.db.collection(table).update({}, { $set: object }, { multi: true });
-		}
-		throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
+		return this.db.collection(table).aggregate({ $sample: { size: 1 } });
 	}
 
 	/**

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -1,4 +1,4 @@
-const { Provider, util: { mergeDefault } } = require('klasa');
+const { Provider, util: { mergeDefault, mergeObjects, isObject } } = require('klasa');
 
 const { MongoClient: Mongo } = require('mongodb');
 
@@ -16,7 +16,12 @@ module.exports = class extends Provider {
 			db: 'klasa',
 			options: {}
 		}, this.client.options.providers.mongodb);
-		const mongoClient = await Mongo.connect(`mongodb://${connection.host}:${connection.port}/`, Object.assign(connection.options, { auth: { user: connection.user, password: connection.password } }));
+		const mongoClient = await Mongo.connect(`mongodb://${connection.host}:${connection.port}/`, mergeObjects(connection.options, {
+			auth: {
+				user: connection.user,
+				password: connection.password
+			}
+		}));
 		this.db = mongoClient.db(connection.db);
 	}
 
@@ -108,7 +113,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object>}
 	 */
 	getRandom(table) {
-		return this.getAll(table).then(results => results[Math.floor(Math.random() * results.length)]);
+		return this.getKeys(table).then(results => this.get(table, results[Math.floor(Math.random() * results.length)].id));
 	}
 
 	/**
@@ -173,19 +178,11 @@ module.exports = class extends Provider {
 	 * Inserts a Document into a Collection using a user provided object.
 	 * @param {string} table Name of the Collection
 	 * @param {(string|Object)} id ID of the document
-	 * @param {Object} doc Document Object to insert
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc Document Object to insert
 	 * @returns {Promise}
 	 */
 	create(table, id, doc = {}) {
-		return this.db.collection(table).insertOne(Object.assign(doc, resolveQuery(id)));
-	}
-
-	set(...args) {
-		return this.create(...args);
-	}
-
-	insert(...args) {
-		return this.create(...args);
+		return this.db.collection(table).insertOne(mergeObjects(this.parseUpdateInput(doc), resolveQuery(id)));
 	}
 
 	/**
@@ -202,24 +199,24 @@ module.exports = class extends Provider {
 	 * Updates a Document using MongoDB Update Operators. *
 	 * @param {string} table Name of the Collection
 	 * @param {Object} id The Filter used to select the document to update
-	 * @param {Object} doc The update operations to be applied to the document
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc The update operations to be applied to the document
 	 * @returns {Promise<void>}
 	 */
 	update(table, id, doc) {
-		return this.db.collection(table).updateOne(resolveQuery(id), { $set: doc });
+		return this.db.collection(table).updateOne(resolveQuery(id), { $set: this.parseUpdateInput(doc) });
 	}
 
 	/**
 	 * Replaces a Document with a new Document specified by the user *
 	 * @param {string} table Name of the Collection
 	 * @param {Object} id The Filter used to select the document to update
-	 * @param {Object} doc The Document that replaces the matching document
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc The Document that replaces the matching document
 	 * @returns {Promise<void>}
 	 */
 	replace(table, id, doc) {
-		return this.db.collection(table).replaceOne(resolveQuery(id), doc);
+		return this.db.collection(table).replaceOne(resolveQuery(id), this.parseUpdateInput(doc));
 	}
 
 };
 
-const resolveQuery = query => query instanceof Object ? query : { id: query };
+const resolveQuery = query => isObject(query) ? query : { id: query };

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -55,7 +55,7 @@ module.exports = class extends SQLProvider {
 	hasTable(table) {
 		return this.run(`IF ( EXISTS (
 			SELECT *
-           	FROM  INFORMATION_SCHEMA.TABLES
+           	FROM INFORMATION_SCHEMA.TABLES
 			WHERE TABLE_NAME = @0
 		) )`, [table]);
 	}
@@ -100,7 +100,7 @@ module.exports = class extends SQLProvider {
 	/**
 	 * @param {string} table The name of the table to get the data from
 	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*}    [value] The value to filter the data from. Requires the key parameter
+	 * @param {*} [value] The value to filter the data from. Requires the key parameter
 	 * @param {number} [limit] The maximum range. Must be higher than the limitMin parameter
 	 * @returns {Promise<Object[]>}
 	 */
@@ -125,7 +125,7 @@ module.exports = class extends SQLProvider {
 	/**
 	 * @param {string} table The name of the table to get the data from
 	 * @param {string} key The key to filter the data from
-	 * @param {*}    [value] The value of the filtered key
+	 * @param {*} [value] The value of the filtered key
 	 * @returns {Promise<Object>}
 	 */
 	get(table, key, value) {
@@ -140,7 +140,7 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} id    The value of the id
+	 * @param {string} id The value of the id
 	 * @returns {Promise<boolean>}
 	 */
 	has(table, id) {

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -5,22 +5,18 @@
  * #####################################
  */
 
-const { Provider, util } = require('klasa');
+const { SQLProvider, util: { mergeDefault, isNumber } } = require('klasa');
 const mssql = require('mssql');
 
-module.exports = class extends Provider {
+module.exports = class extends SQLProvider {
 
 	constructor(...args) {
-		super(...args, {
-			enabled: true,
-			sql: true,
-			description: 'Allows you to use MSSQL functionality throught Klasa'
-		});
+		super(...args);
 		this.pool = null;
 	}
 
 	async init() {
-		const connection = util.mergeDefault({
+		const connection = mergeDefault({
 			host: 'localhost',
 			db: 'klasa',
 			user: 'database-user',
@@ -70,7 +66,17 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object[]>}
 	 */
 	createTable(table, rows) {
-		return this.run(`CREATE TABLE @0 ( ${rows.map(([k, v]) => `${k} ${v}`).join(', ')} );`, [table]);
+		if (rows) return this.run(`CREATE TABLE @0 ( ${rows.map(([k, v]) => `${k} ${v}`).join(', ')} );`, [table]);
+
+		const gateway = this.client.gateways[table];
+		if (!gateway) throw new Error(`There is no gateway defined with the name ${table} nor an array of rows with datatypes have been given. Expected any of either.`);
+
+		const schemaValues = [...gateway.schema.values(true)];
+		return this.run(`
+			CREATE TABLE @0 (
+				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE${schemaValues.length ? `, ${schemaValues.map(this.qb.parse.bind(this.qb)).join(', ')}` : ''}
+			)`, [table]
+		);
 	}
 
 	/**
@@ -100,10 +106,12 @@ module.exports = class extends Provider {
 	 */
 	getAll(table, key, value, limit) {
 		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
-			return this.run(`SELECT ${parseRange(limit)} * FROM @0 WHERE @1 = @2;`, [table, key, value]);
+			return this.run(`SELECT ${parseRange(limit)} * FROM @0 WHERE @1 = @2;`, [table, key, value])
+				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 
-		return this.run(`SELECT ${parseRange(limit)} * FROM @0;`, [table]);
+		return this.run(`SELECT ${parseRange(limit)} * FROM @0;`, [table])
+			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 
 	/**
@@ -126,7 +134,8 @@ module.exports = class extends Provider {
 			value = key;
 			key = 'id';
 		}
-		return this.run('SELECT TOP 1 * FROM @0 WHERE @1 = @2;', [table, key, value]);
+		return this.run('SELECT TOP 1 * FROM @0 WHERE @1 = @2;', [table, key, value])
+			.then(result => this.parseEntry(table, result));
 	}
 
 	/**
@@ -143,11 +152,18 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object>}
 	 */
 	getRandom(table) {
-		return this.run('SELECT TOP 1 * FROM @0 ORDER BY NEWID();', [table]);
+		return this.run('SELECT TOP 1 * FROM @0 ORDER BY NEWID();', [table])
+			.then(result => this.parseEntry(table, result));
 	}
 
-	create(table, id, param1, param2) {
-		const [keys, values] = acceptArbitraryInput(param1, param2);
+	/**
+	 * @param {string} table The name of the table to insert the new data
+	 * @param {string} id The id of the new row to insert
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} data The data to update
+	 * @returns {Promise<any[]>}
+	 */
+	create(table, id, data) {
+		const [keys, values] = this.parseUpdateInput(data, false);
 
 		// Push the id to the inserts.
 		keys.push('id');
@@ -158,32 +174,13 @@ module.exports = class extends Provider {
 	}
 
 	/**
-	 * @param {...*} args The arguments
-	 * @alias MSSQL#insert
-	 * @returns {Promise<any[]>}
-	 */
-	set(...args) {
-		return this.create(...args);
-	}
-
-	/**
-	 * @param {...*} args The arguments
-	 * @alias MSSQL#insert
-	 * @returns {Promise<any[]>}
-	 */
-	insert(...args) {
-		return this.create(...args);
-	}
-
-	/**
 	 * @param {string} table The name of the table to update the data from
 	 * @param {string} id The id of the row to update
-	 * @param {(string|string[]|{})} param1 The first parameter to validate.
-	 * @param {*} [param2] The second parameter to validate.
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} data The data to update
 	 * @returns {Promise<any[]>}
 	 */
-	update(table, id, param1, param2) {
-		const [keys, values] = acceptArbitraryInput(param1, param2);
+	update(table, id, data) {
+		const [keys, values] = this.parseUpdateInput(data, false);
 		return this.run(`
 			UPDATE ${sanitizeKeyName(table)}
 			SET ${keys.map((key, i) => `${sanitizeKeyName(key)} = @${i}`)}
@@ -213,18 +210,14 @@ module.exports = class extends Provider {
 
 	/**
 	 * Add a new column to a table's schema.
-	 * @param {string} table The name of the table to edit.
-	 * @param {(string|Array<string[]>)} key The key to add.
-	 * @param {string} [datatype] The datatype for the new key.
-	 * @returns {Promise<any[]>}
+	 * @param {string} table The table to check against
+	 * @param {(SchemaFolder | SchemaPiece)} piece The SchemaFolder or SchemaPiece added to the schema
+	 * @returns {Promise<*>}
 	 */
-	addColumn(table, key, datatype) {
-		if (typeof key === 'string') return this.run(`ALTER TABLE @0 ADD @1 @2;`, [table, key, datatype]);
-		if (typeof datatype === 'undefined' && Array.isArray(key)) {
-			return this.run(`ALTER TABLE @0 ${key.map(([column, type]) =>
-				`ADD ${sanitizeKeyName(column)} ${type}`).join(', ')};`, [table]);
-		}
-		throw new TypeError('Invalid usage of MSSQL#addColumn. Expected a string and string or string[][] and undefined.');
+	addColumn(table, piece) {
+		return this.run(piece.type !== 'Folder' ?
+			`ALTER TABLE ${sanitizeKeyName(table)} ADD ${this.qb.parse(piece)};` :
+			`ALTER TABLE ${sanitizeKeyName(table)} ${[...piece.values(true)].map(subpiece => `ADD ${this.qb.parse(subpiece)}`).join(', ')}`);
 	}
 
 	/**
@@ -234,30 +227,22 @@ module.exports = class extends Provider {
 	 * @returns {Promise<any[]>}
 	 */
 	removeColumn(table, key) {
-		if (typeof key === 'string') {
-			return this.run(`
-				ALTER TABLE @0
-				DROP COLUMN @1;`, [table, key]);
-		}
-		if (Array.isArray(key)) {
-			return this.run(`
-				ALTER TABLE @0
-				DROP ${key.map(sanitizeKeyName).join(', ')};`, [table]);
-		}
+		if (typeof key === 'string') return this.run(`ALTER TABLE @0 DROP COLUMN @1;`, [table, key]);
+		if (Array.isArray(key)) return this.run(`ALTER TABLE @0 DROP ${key.map(sanitizeKeyName).join(', ')};`, [table]);
 		throw new TypeError('Invalid usage of MSSQL#removeColumn. Expected a string or string[].');
 	}
 
 	/**
 	 * Edit the key's datatype from the table's schema.
-	 * @param {string} table The name of the table to edit.
-	 * @param {string} key The name of the column to update.
-	 * @param {string} datatype The new datatype for the column.
+	 * @param {string} table The table to update
+	 * @param {SchemaPiece} piece The modified SchemaPiece
 	 * @returns {Promise<any[]>}
 	 */
-	updateColumn(table, key, datatype) {
+	updateColumn(table, piece) {
+		const [column, ...datatype] = this.qb.parse(piece).split(' ');
 		return this.run(`
 			ALTER TABLE @0
-			ALTER COLUMN @1 @2;`, [table, key, datatype]);
+			ALTER COLUMN @1 @2;`, [table, column, datatype]);
 	}
 
 	/**
@@ -280,50 +265,6 @@ module.exports = class extends Provider {
 	}
 
 };
-
-/**
- * Accept any kind of input from two parameters.
- * @param {(string|string[]|{})} param1 The first parameter to validate.
- * @param {*} [param2] The second parameter to validate.
- * @returns {[[], []]}
- * @private
- */
-function acceptArbitraryInput(param1, param2) {
-	if (typeof param1 === 'undefined' && typeof param2 === 'undefined') return [[], []];
-	if (typeof param1 === 'string' && typeof param2 !== 'undefined') return [[param1], [param2]];
-	if (Array.isArray(param1) && Array.isArray(param2)) {
-		if (param1.length !== param2.length) throw new TypeError(`The array lengths do not match: ${param1.length}-${param2.length}`);
-		if (param1.some(value => typeof value !== 'string')) throw new TypeError(`The array of keys must be an array of strings, but found a value that does not match.`);
-		return [param1, param2];
-	}
-	if (util.isObject(param1) && typeof param2 === 'undefined') {
-		const entries = [[], []];
-		getEntriesFromObject(param1, entries, '');
-		return entries;
-	}
-	throw new TypeError('Invalid input. Expected a key type of string and a value, tuple of arrays, or an object and undefined.');
-}
-
-/**
- * Get all entries from an object.
- * @param {Object} object The object to "flatify".
- * @param {[string[], any[]]} param1 The tuple of keys and values to check.
- * @param {string} path The current path.
- * @private
- */
-function getEntriesFromObject(object, [keys, values], path) {
-	const objectKeys = Object.keys(object);
-	for (let i = 0; i < objectKeys.length; i++) {
-		const key = objectKeys[i];
-		const value = object[key];
-		if (util.isObject(value)) {
-			getEntriesFromObject(value, [keys, values], path.length > 0 ? `${path}.${key}` : key);
-		} else {
-			keys.push(path.length > 0 ? `${path}.${key}` : key);
-			values.push(value);
-		}
-	}
-}
 
 /**
  * @param {string} value The string to sanitize
@@ -357,7 +298,7 @@ function sanitizeKeyName(value) {
  * @private
  */
 function parseRange(number, all = true) {
-	return util.isNumber(number) ? `TOP ${number}` : all ? 'ALL' : '';
+	return isNumber(number) ? `TOP ${number}` : all ? 'ALL' : '';
 }
 
 function makeVariables(number) {

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -5,7 +5,7 @@
  * #####################################
  */
 
-const { SQLProvider, QueryBuilder, Timestamp, Type, util: { mergeDefault, isNumber } } = require('klasa');
+const { SQLProvider, QueryBuilder, Timestamp, Type, util: { mergeDefault } } = require('klasa');
 const mssql = require('mssql');
 
 const TIMEPARSERS = {
@@ -114,18 +114,15 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*} [value] The value to filter the data from. Requires the key parameter
-	 * @param {number} [limit] The maximum range. Must be higher than the limitMin parameter
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limit) {
-		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
-			return this.run(`SELECT ${parseRange(limit)} * FROM @0 WHERE @1 = @2;`, [table, key, value])
+	getAll(table, entries = []) {
+		if (entries.length) {
+			return this.run(`SELECT * FROM @0 WHERE id IN (@1);`, [table, `'${entries.join("', '")}'`])
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
-
-		return this.run(`SELECT ${parseRange(limit)} * FROM @0;`, [table])
+		return this.run(`SELECT * FROM @0;`, [table])
 			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 
@@ -301,14 +298,4 @@ function sanitizeKeyName(value) {
 	if (typeof value !== 'string') throw new TypeError(`%MSSQL.sanitizeString expects a string, got: ${new Type(value)}`);
 	if (/`/.test(value)) throw new TypeError(`Invalid input (${value}).`);
 	return value;
-}
-
-/**
- * @param {number} [number] The limit number.
- * @param {boolean} [all] If it should show all.
- * @returns {string}
- * @private
- */
-function parseRange(number, all = true) {
-	return isNumber(number) ? `TOP ${number}` : all ? 'ALL' : '';
 }

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -19,17 +19,14 @@ module.exports = class extends SQLProvider {
 		super(...args);
 		this.qb = new QueryBuilder({
 			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'` },
-			boolean: { type: 'BIT(1)', resolver: (input) => input ? 1 : 0 },
+			boolean: { type: 'BIT(1)', resolver: (input) => input ? '1' : '0' },
 			date: { type: 'DATETIME', resolver: (input) => TIMEPARSERS.DATETIME.display(input) },
 			float: 'DOUBLE PRECISION',
 			integer: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER',
 			json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'` },
 			null: 'NULL',
 			time: { type: 'DATETIME', resolver: (input) => TIMEPARSERS.DATETIME.display(input) },
-			timestamp: { type: 'TIMESTAMP', resolver: (input) => TIMEPARSERS.DATE.display(input) },
-			array: type => type,
-			arrayResolver: (values) => `'${sanitizeString(JSON.stringify(values))}'`,
-			formatDatatype: (name, datatype, def = null) => `\`${name}\` ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
+			timestamp: { type: 'TIMESTAMP', resolver: (input) => TIMEPARSERS.DATE.display(input) }
 		});
 		this.db = null;
 	}

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -110,19 +110,15 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*} [value] The value to filter the data from. Requires the key parameter
-	 * @param {number} [limitMin] The minimum range. Must be higher than zero
-	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limitMin, limitMax) {
-		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = ${sanitizeInput(value)} ${parseRange(limitMin, limitMax)};`)
+	getAll(table, entries = []) {
+		if (entries.length) {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}');`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
-
-		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} ${parseRange(limitMin, limitMax)};`)
+		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
 			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -90,7 +90,7 @@ module.exports = class extends SQLProvider {
 	/**
 	 * @param {string} table The name of the table to get the data from
 	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*}    [value] The value to filter the data from. Requires the key parameter
+	 * @param {*} [value] The value to filter the data from. Requires the key parameter
 	 * @param {number} [limitMin] The minimum range. Must be higher than zero
 	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
 	 * @returns {Promise<Object[]>}
@@ -117,7 +117,7 @@ module.exports = class extends SQLProvider {
 	/**
 	 * @param {string} table The name of the table to get the data from
 	 * @param {string} key The key to filter the data from
-	 * @param {*}    [value] The value of the filtered key
+	 * @param {*} [value] The value of the filtered key
 	 * @returns {Promise<Object>}
 	 */
 	get(table, key, value) {
@@ -132,7 +132,7 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} id    The value of the id
+	 * @param {string} id The value of the id
 	 * @returns {Promise<boolean>}
 	 */
 	has(table, id) {

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -29,7 +29,7 @@ module.exports = class extends SQLProvider {
 			timestamp: { type: 'TIMESTAMP', resolver: (input) => TIMEPARSERS.DATE.display(input) },
 			array: type => type,
 			arrayResolver: (values) => `'${sanitizeString(JSON.stringify(values))}'`,
-			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
+			formatDatatype: (name, datatype, def = null) => `\`${name}\` ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
 		});
 		this.db = null;
 	}

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -18,17 +18,17 @@ module.exports = class extends SQLProvider {
 	constructor(...args) {
 		super(...args);
 		this.qb = new QueryBuilder({
-			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'` },
+			any: { type: 'JSON', resolver: (input) => sanitizeObject(input) },
 			boolean: { type: 'BIT(1)', resolver: (input) => input ? '1' : '0' },
 			date: { type: 'DATETIME', resolver: (input) => TIMEPARSERS.DATETIME.display(input) },
 			float: 'DOUBLE PRECISION',
 			integer: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER',
-			json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'` },
+			json: { type: 'JSON', resolver: (input) => sanitizeObject(input) },
 			null: 'NULL',
 			time: { type: 'DATETIME', resolver: (input) => TIMEPARSERS.DATETIME.display(input) },
 			timestamp: { type: 'TIMESTAMP', resolver: (input) => TIMEPARSERS.DATE.display(input) },
 			array: () => 'ARRAY',
-			arrayResolver: (values) => values.length ? `'${JSON.stringify(values)}'` : "'[]'",
+			arrayResolver: (values) => values.length ? sanitizeObject(values) : "'[]'",
 			formatDatatype: (name, datatype, def = null) => datatype === 'ARRAY' ?
 				`${sanitizeKeyName(name)} TEXT` :
 				`${sanitizeKeyName(name)} ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`

--- a/providers/nedb.js
+++ b/providers/nedb.js
@@ -63,8 +63,10 @@ module.exports = class extends Provider {
 	 * @param {string} table The name of the table to get all entries from.
 	 * @returns {Promise<Object[]>}
 	 */
-	async getAll(table) {
-		const entries = await this.dataStores.get(table).findAsync({});
+	async getAll(table, filter = []) {
+		let entries;
+		if (filter.length) entries = await this.dataStores.get(table).findAsync({ id: { $in: filter } });
+		else entries = await this.dataStores.get(table).findAsync({});
 		for (const entry of entries) delete entry._id;
 		return entries;
 	}

--- a/providers/neo4j.js
+++ b/providers/neo4j.js
@@ -1,0 +1,222 @@
+const { Provider, util: { mergeDefault, makeObject, isObject, mergeObjects } } = require('klasa');
+const { v1: neo4j } = require('neo4j-driver');
+
+module.exports = class extends Provider {
+
+	constructor(...args) {
+		super(...args);
+		this.db = null;
+	}
+
+	init() {
+		const { host, username, password } = mergeDefault({
+			host: 'bolt://localhost',
+			username: 'neo4j',
+			password: 'neo4j'
+		}, this.client.options.providers.neo4j);
+
+		const driver = neo4j.driver(host, neo4j.auth.basic(username, password));
+		this.db = driver.session();
+	}
+
+	/**
+	 * Checks if a table exists.
+	 * @param {string} table The name of the table you want to check.
+	 * @returns {Promise<boolean>}
+	 */
+	hasTable(table) {
+		return this.db.run(`MATCH (n:${table}) RETURN n`).then(data => Boolean(data.records.length));
+	}
+
+	/**
+	 * Create a collection within a DB. Options may be specfied, refer to Neo4j docs.
+	 * @param {string} table Name of the Collection to crate
+	 * @returns {Promise<*>} Returns a promise containing the created Collection.
+	 */
+	createTable(table) {
+		return this.db.run(`CREATE (n:${table}) RETURN n`).then(data => data.records.map(node => node._fields[0].identity.low)[0]);
+	}
+
+	/**
+	 * Drops a collection within a DB.
+	 * @param {string} table Name of the collection to drop.
+	 * @returns {Promise<void>}
+	 */
+	deleteTable(table) {
+		return this.db.run(`MATCH (n:${table}) DELETE n`);
+	}
+
+	/**
+	 * Retrieves all Documents in a collection.
+	 * @param {string} table Name of the Collection
+	 * @returns {Promise<Array>}
+	 */
+	getAll(table) {
+		return this.db.run(`MATCH (n:${table}) RETURN n`).then(data => data.records.map(node => node._fields[0].properties));
+	}
+
+	/**
+	 * Retrives all the keys in a collection.
+	 * @param {string} table The name of the table you want to get the data from.
+	 * @returns {Promise<string[]>}
+	 */
+	getKeys(table) {
+		return this.db.run(`MATCH (n:${table}) RETURN n`).then(data => data.records.map(node => node._fields[0].identity.low));
+	}
+
+	/**
+	 * Retrieves a single Document from a Collection that matches a user determined ID
+	 * @param {string} table Name of the Collection
+	 * @param {string|Object} id ID of the document
+	 * @returns {Promise<*>}
+	 */
+	get(table, id) {
+		return this.db.run(`MATCH (n:${table}) WHERE n.id = ${typeof id === 'string' ? `'${id}'` : id} RETURN n`)
+			.then(data => data.records.map(node => this.packData(node._fields[0].properties, node._fields[0].identity.low))[0]);
+	}
+
+	/**
+	 * Checks if a document from a Collection exists.
+	 * @param {string} table Name of the Collection
+	 * @param {string} id ID of the document
+	 * @returns {Promise<boolean>}
+	 */
+	has(table, id) {
+		return this.db.run(`MATCH (n:${table} {id: {id} }) RETURN n`, { id }).then(data => Boolean(data.records.length));
+	}
+
+	/**
+	 * Inserts a Document into a Collection using a user provided object.
+	 * @param {string} table Name of the Collection
+	 * @param {(string|Object)} id ID of the document
+	 * @param {Object} doc Document Object to insert
+	 * @returns {Promise<Object>}
+	 */
+	create(table, id, doc = {}) {
+		console.log('Created new with id', id);
+		return this.db.run(`CREATE (n:${table} ${JSON.stringify({ id, ...this.parseUpdateInput(doc) }).replace(/"([^"]+)":/g, '$1:')}) RETURN n`);
+	}
+
+	/**
+	 * Updates a Document using Neo4j Update Operators. *
+	 * @param {string} table Name of the Collection
+	 * @param {Object} id The Filter used to select the document to update
+	 * @param {Object} doc The update operations to be applied to the document
+	 * @returns {Promise<void>}
+	 */
+	update(table, id, doc) {
+		console.log('Updated with ID', id);
+		const object = this.constructFlatObject(this.parseUpdateInput(doc));
+		return this.db.run(`MATCH (n:${table} {id : {id} }) SET ${object} RETURN n`, { id });
+	}
+
+	/**
+	 * Deletes a Document from a Collection that matches a user determined ID *
+	 * @param {string} table Name of the Collection
+	 * @param {string} id ID of the document
+	 * @returns {Promise<void>}
+	 */
+	delete(table, id) {
+		return this.db.run(`MATCH (n:${table} {id: {id} }) DELETE n`, { id });
+	}
+
+	/**
+	 * Replaces a Document with a new Document specified by the user *
+	 * @param {string} table Name of the Collection
+	 * @param {Object} id The Filter used to select the document to update
+	 * @param {Object} doc The Document that replaces the matching document
+	 * @returns {Promise<void>}
+	 */
+	async replace(table, id, doc) {
+		const { data } = await this.get(table, id);
+		const object = this.constructFlatObject(mergeObjects(data, this.parseUpdateInput(doc)));
+		return this.db.run(`MATCH (n:${table} {id : {id} }) SET ${object} RETURN n`, { id });
+	}
+
+	/**
+	 * Update or insert a new value to all entries.
+	 * @param {string} table The name of the table.
+	 * @param {string} path The object to remove or a path to update.
+	 * @param {*} newValue The new value for the key.
+     */
+	async updateValue(table, path, newValue) {
+		const keys = await this.getKeys(table);
+		if (isObject(path) && typeof newValue === 'undefined') {
+			await Promise.all(keys.map(async node => await this.updatebyID(table, node, path)));
+		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
+			await Promise.all(keys.map(async node => await this.updatebyID(table, node, makeObject(path, newValue))));
+		} else {
+			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
+		}
+	}
+	/**
+	 * Remove a value or object from all entries.
+	 * @param {string} table The name of the table.
+	 * @param {string} path The object to remove or a path to update.
+	 */
+	async removeValue(table, path) {
+		const keys = await this.getKeys(table);
+		if (isObject(path) && typeof newValue === 'undefined') {
+			await Promise.all(keys.map(node => this.remove(table, node, path)));
+		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
+			await Promise.all(keys.map(node => this.remove(table, node, makeObject(path, null))));
+		} else {
+			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
+		}
+	}
+	/**
+	 * @param {string} table Name of the Collection
+	 * @param {string} id ID of the document
+	 * @param {string} path Object to be removed
+     * @private
+	 */
+	async remove(table, id, path) {
+		const [entry] = this.db.run(`MATCH (n:${table} {id: {id} }) RETURN n`, { id }).then(data => data.records.map(node => node._fields[0].properties));
+		Object.keys(path).map(key => delete entry[key]);
+		await this.updatebyID(table, id, entry);
+	}
+
+	/**
+	 * Updates a Document using ID assigned by Neo *
+	 * @param {string} table Name of the Collection
+	 * @param {Object} id The Filter used to select the document to update
+	 * @param {Object} doc The update operations to be applied to the document
+	 * @returns {Promise<void>}
+	 */
+	updatebyID(table, id, doc) {
+		const object = this.constructFlatObject(this.parseUpdateInput(doc));
+		return this.db.run(`MATCH (n:${table}) WHERE ID(n) = ${id} SET ${object} RETURN n`);
+	}
+
+	/**
+     * Flattes the Object into a string, to be parsed by Cypher.
+     * @private
+     * @param {Object} object The Object to be flattened
+     * @returns {string}
+     * @private
+     */
+	constructFlatObject(object) {
+		const string = [];
+		Object.entries(object).map(([key, value]) => {
+			if (isObject(object)) value = JSON.stringify(value).replace(/"([^"]+)":/g, '$1:');
+			return string.push(`n.${key} = ${typeof string === 'string' ? `'${value}'` : value}`);
+		});
+		return string.join(', ');
+	}
+
+	/**
+     * Packs the data into easy-to-use manner
+     * @param {*} data :)
+     * @param {*} id   (:
+     * @returns {Object}
+     * @private
+     */
+	packData(data, id) {
+		return {
+			...data,
+			uuid: id
+		};
+	}
+
+};
+

--- a/providers/neo4j.js
+++ b/providers/neo4j.js
@@ -19,141 +19,69 @@ module.exports = class extends Provider {
 		this.db = driver.session();
 	}
 
-	/**
-	 * Checks if a table exists.
-	 * @param {string} table The name of the table you want to check.
-	 * @returns {Promise<boolean>}
-	 */
 	hasTable(table) {
 		return this.db.run(`MATCH (n:${table}) RETURN n`).then(data => Boolean(data.records.length));
 	}
 
-	/**
-	 * Create a collection within a DB. Options may be specfied, refer to Neo4j docs.
-	 * @param {string} table Name of the Collection to crate
-	 * @returns {Promise<*>} Returns a promise containing the created Collection.
-	 */
 	createTable(table) {
 		return this.db.run(`CREATE (n:${table}) RETURN n`).then(data => data.records.map(node => node._fields[0].identity.low)[0]);
 	}
 
-	/**
-	 * Drops a collection within a DB.
-	 * @param {string} table Name of the collection to drop.
-	 * @returns {Promise<void>}
-	 */
 	deleteTable(table) {
 		return this.db.run(`MATCH (n:${table}) DELETE n`);
 	}
 
-	/**
-	 * Retrieves all Documents in a collection.
-	 * @param {string} table Name of the Collection
-	 * @returns {Promise<Array>}
-	 */
-	getAll(table) {
-		return this.db.run(`MATCH (n:${table}) RETURN n`).then(data => data.records.map(node => node._fields[0].properties));
-	}
-
-	/**
-	 * Retrives all the keys in a collection.
-	 * @param {string} table The name of the table you want to get the data from.
-	 * @returns {Promise<string[]>}
-	 */
 	getKeys(table) {
 		return this.db.run(`MATCH (n:${table}) RETURN n`).then(data => data.records.map(node => node._fields[0].identity.low));
 	}
 
-	/**
-	 * Retrieves a single Document from a Collection that matches a user determined ID
-	 * @param {string} table Name of the Collection
-	 * @param {string|Object} id ID of the document
-	 * @returns {Promise<*>}
-	 */
 	get(table, id) {
 		return this.db.run(`MATCH (n:${table}) WHERE n.id = ${typeof id === 'string' ? `'${id}'` : id} RETURN n`)
-			.then(data => data.records.map(node => this.packData(node._fields[0].properties, node._fields[0].identity.low))[0]);
+			.then(data => data.records.map(node => node._fields[0].properties)[0]);
 	}
 
-	/**
-	 * Checks if a document from a Collection exists.
-	 * @param {string} table Name of the Collection
-	 * @param {string} id ID of the document
-	 * @returns {Promise<boolean>}
-	 */
 	has(table, id) {
 		return this.db.run(`MATCH (n:${table} {id: {id} }) RETURN n`, { id }).then(data => Boolean(data.records.length));
 	}
 
-	/**
-	 * Inserts a Document into a Collection using a user provided object.
-	 * @param {string} table Name of the Collection
-	 * @param {(string|Object)} id ID of the document
-	 * @param {Object} doc Document Object to insert
-	 * @returns {Promise<Object>}
-	 */
 	create(table, id, doc = {}) {
-		console.log('Created new with id', id);
 		return this.db.run(`CREATE (n:${table} ${JSON.stringify({ id, ...this.parseUpdateInput(doc) }).replace(/"([^"]+)":/g, '$1:')}) RETURN n`);
 	}
 
-	/**
-	 * Updates a Document using Neo4j Update Operators. *
-	 * @param {string} table Name of the Collection
-	 * @param {Object} id The Filter used to select the document to update
-	 * @param {Object} doc The update operations to be applied to the document
-	 * @returns {Promise<void>}
-	 */
 	update(table, id, doc) {
-		console.log('Updated with ID', id);
 		const object = this.constructFlatObject(this.parseUpdateInput(doc));
 		return this.db.run(`MATCH (n:${table} {id : {id} }) SET ${object} RETURN n`, { id });
 	}
 
-	/**
-	 * Deletes a Document from a Collection that matches a user determined ID *
-	 * @param {string} table Name of the Collection
-	 * @param {string} id ID of the document
-	 * @returns {Promise<void>}
-	 */
 	delete(table, id) {
 		return this.db.run(`MATCH (n:${table} {id: {id} }) DELETE n`, { id });
 	}
 
-	/**
-	 * Replaces a Document with a new Document specified by the user *
-	 * @param {string} table Name of the Collection
-	 * @param {Object} id The Filter used to select the document to update
-	 * @param {Object} doc The Document that replaces the matching document
-	 * @returns {Promise<void>}
-	 */
+	updatebyID(table, id, doc) {
+		const object = this.constructFlatObject(this.parseUpdateInput(doc));
+		return this.db.run(`MATCH (n:${table}) WHERE ID(n) = ${id} SET ${object} RETURN n`);
+	}
+
+	constructFlatObject(object) {
+		const string = [];
+		Object.entries(object).map(([key, value]) => {
+			if (isObject(object)) value = JSON.stringify(value).replace(/"([^"]+)":/g, '$1:');
+			return string.push(`n.${key} = ${typeof string === 'string' ? `'${value}'` : value}`);
+		});
+		return string.join(', ');
+	}
+
+	async getAll(table, filter = []) {
+		return await this.db.run(`MATCH (n:${table}) ${filter.length ? `WHERE n.id IN ${filter}` : ''}RETURN n`)
+			.then(data => data.records.map(node => node._fields[0].properties));
+	}
+
 	async replace(table, id, doc) {
 		const { data } = await this.get(table, id);
 		const object = this.constructFlatObject(mergeObjects(data, this.parseUpdateInput(doc)));
 		return this.db.run(`MATCH (n:${table} {id : {id} }) SET ${object} RETURN n`, { id });
 	}
 
-	/**
-	 * Update or insert a new value to all entries.
-	 * @param {string} table The name of the table.
-	 * @param {string} path The object to remove or a path to update.
-	 * @param {*} newValue The new value for the key.
-     */
-	async updateValue(table, path, newValue) {
-		const keys = await this.getKeys(table);
-		if (isObject(path) && typeof newValue === 'undefined') {
-			await Promise.all(keys.map(async node => await this.updatebyID(table, node, path)));
-		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
-			await Promise.all(keys.map(async node => await this.updatebyID(table, node, makeObject(path, newValue))));
-		} else {
-			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
-		}
-	}
-	/**
-	 * Remove a value or object from all entries.
-	 * @param {string} table The name of the table.
-	 * @param {string} path The object to remove or a path to update.
-	 */
 	async removeValue(table, path) {
 		const keys = await this.getKeys(table);
 		if (isObject(path) && typeof newValue === 'undefined') {
@@ -164,58 +92,11 @@ module.exports = class extends Provider {
 			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
 		}
 	}
-	/**
-	 * @param {string} table Name of the Collection
-	 * @param {string} id ID of the document
-	 * @param {string} path Object to be removed
-     * @private
-	 */
+
 	async remove(table, id, path) {
 		const [entry] = this.db.run(`MATCH (n:${table} {id: {id} }) RETURN n`, { id }).then(data => data.records.map(node => node._fields[0].properties));
 		Object.keys(path).map(key => delete entry[key]);
 		await this.updatebyID(table, id, entry);
-	}
-
-	/**
-	 * Updates a Document using ID assigned by Neo *
-	 * @param {string} table Name of the Collection
-	 * @param {Object} id The Filter used to select the document to update
-	 * @param {Object} doc The update operations to be applied to the document
-	 * @returns {Promise<void>}
-	 */
-	updatebyID(table, id, doc) {
-		const object = this.constructFlatObject(this.parseUpdateInput(doc));
-		return this.db.run(`MATCH (n:${table}) WHERE ID(n) = ${id} SET ${object} RETURN n`);
-	}
-
-	/**
-     * Flattes the Object into a string, to be parsed by Cypher.
-     * @private
-     * @param {Object} object The Object to be flattened
-     * @returns {string}
-     * @private
-     */
-	constructFlatObject(object) {
-		const string = [];
-		Object.entries(object).map(([key, value]) => {
-			if (isObject(object)) value = JSON.stringify(value).replace(/"([^"]+)":/g, '$1:');
-			return string.push(`n.${key} = ${typeof string === 'string' ? `'${value}'` : value}`);
-		});
-		return string.join(', ');
-	}
-
-	/**
-     * Packs the data into easy-to-use manner
-     * @param {*} data :)
-     * @param {*} id   (:
-     * @returns {Object}
-     * @private
-     */
-	packData(data, id) {
-		return {
-			...data,
-			uuid: id
-		};
 	}
 
 };

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -67,9 +67,11 @@ module.exports = class PostgreSQL extends SQLProvider {
 		if (rows) return this.run(`CREATE TABLE ${sanitizeKeyName(table)} (${rows.map(([k, v]) => `${sanitizeKeyName(k)} ${v}`).join(', ')});`);
 		const gateway = this.client.gateways[table];
 		if (!gateway) throw new Error(`There is no gateway defined with the name ${table} nor an array of rows with datatypes have been given. Expected any of either.`);
+
+		const schemaValues = [...gateway.schema.values(true)];
 		return this.run(`
 			CREATE TABLE ${sanitizeKeyName(table)} (
-				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE, ${[...gateway.schema.values(true)].map(this.qb.parse.bind(this.qb)).join(', ')}
+				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE${schemaValues.length ? `, ${schemaValues.map(this.qb.parse.bind(this.qb)).join(', ')}` : ''},
 			)`
 		);
 	}

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -6,10 +6,10 @@ module.exports = class PostgreSQL extends SQLProvider {
 	constructor(...args) {
 		super(...args);
 		this.qb = new QueryBuilder({
-			boolean: { type: 'BOOL' },
-			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
-			float: { type: 'DOUBLE PRECISION' },
-			uuid: { type: 'UUID' },
+			boolean: 'BOOL',
+			integer: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER',
+			float: 'DOUBLE PRECISION',
+			uuid: 'UUID',
 			json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
 			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
 			array: type => `${type}[]`,

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -68,7 +68,11 @@ module.exports = class PostgreSQL extends SQLProvider {
 		if (rows) return this.run(`CREATE TABLE ${sanitizeKeyName(table)} (${rows.map(([k, v]) => `${sanitizeKeyName(k)} ${v}`).join(', ')});`);
 		const gateway = this.client.gateways[table];
 		if (!gateway) throw new Error(`There is no gateway defined with the name ${table} nor an array of rows with datatypes have been given. Expected any of either.`);
-		return this.run(`CREATE TABLE ${sanitizeKeyName(table)} (${[...gateway.schema.values(true)].map(this.qb.parse.bind(this.qb))})`);
+		return this.run(`
+			CREATE TABLE ${sanitizeKeyName(table)} (
+				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE, ${[...gateway.schema.values(true)].map(this.qb.parse.bind(this.qb)).join(', ')}
+			)`
+		);
 	}
 
 	/**

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -97,19 +97,15 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*} [value] The value to filter the data from. Requires the key parameter
-	 * @param {number} [limitMin] The minimum range. Must be higher than zero
-	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limitMin, limitMax) {
-		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 ${parseRange(limitMin, limitMax)};`, [value])
+	getAll(table, entries = []) {
+		if (entries.length) {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}');`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
-
-		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} ${parseRange(limitMin, limitMax)};`)
+		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
 			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -140,7 +140,7 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} id    The value of the id
+	 * @param {string} id The value of the id
 	 * @returns {Promise<boolean>}
 	 */
 	has(table, id) {

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -105,11 +105,11 @@ module.exports = class PostgreSQL extends SQLProvider {
 	getAll(table, key, value, limitMin, limitMax) {
 		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 ${parseRange(limitMin, limitMax)};`, [value])
-				.then(results => results.map(this.parseEntry.bind(this)));
+				.then(results => results.map(this.parseEntry.bind(this, table)));
 		}
 
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} ${parseRange(limitMin, limitMax)};`)
-			.then(results => results.map(this.parseEntry.bind(this)));
+			.then(results => results.map(this.parseEntry.bind(this, table)));
 	}
 
 	/**
@@ -133,7 +133,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 			value = key;
 			key = 'id';
 		}
-		return this.runOne(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 LIMIT 1;`, [value]).then(this.parseEntry.bind(this));
+		return this.runOne(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 LIMIT 1;`, [value]).then(this.parseEntry.bind(this, table));
 	}
 
 	/**

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -184,7 +184,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 		values.push(id);
 		return this.run(`
 			INSERT INTO ${sanitizeKeyName(table)} (${keys.map(sanitizeKeyName).join(', ')})
-			VALUES (${Array.from({ length: 9 }, (__, i) => `$${i + 1}`).join(', ')});`, values);
+			VALUES (${Array.from({ length: keys.length }, (__, i) => `$${i + 1}`).join(', ')});`, values);
 	}
 
 	/**

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -10,7 +10,8 @@ module.exports = class PostgreSQL extends SQLProvider {
 			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
 			float: { type: 'DOUBLE PRECISION' },
 			uuid: { type: 'UUID' },
-			any: { type: 'JSON' }
+			json: { type: 'JSON', resolver: (input, { array }) => array ? input.map(value => `'${JSON.stringify(value)}'::json`) : `'${JSON.stringify(input)}'::json` },
+			any: { type: 'JSON', resolver: (input, { array }) => array ? input.map(value => `'${JSON.stringify(value)}'::json`) : `'${JSON.stringify(input)}'::json` }
 		}, {
 			array: type => `${type}[]`,
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -71,7 +71,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 		const schemaValues = [...gateway.schema.values(true)];
 		return this.run(`
 			CREATE TABLE ${sanitizeKeyName(table)} (
-				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE${schemaValues.length ? `, ${schemaValues.map(this.qb.parse.bind(this.qb)).join(', ')}` : ''},
+				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE${schemaValues.length ? `, ${schemaValues.map(this.qb.parse.bind(this.qb)).join(', ')}` : ''}
 			)`
 		);
 	}

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -10,18 +10,11 @@ module.exports = class PostgreSQL extends SQLProvider {
 			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
 			float: { type: 'DOUBLE PRECISION' },
 			uuid: { type: 'UUID' },
-			json: {
-				type: 'JSON', resolver: (input, { array }) => array ?
-					`array[${input.map(value => `'${JSON.stringify(value)}'::json`).join(', ')}]` :
-					`'${JSON.stringify(input)}'::json`
-			},
-			any: {
-				type: 'JSON', resolver: (input, { array }) => array ?
-					`array[${input.map(value => `'${JSON.stringify(value)}'::json`).join(', ')}]` :
-					`'${JSON.stringify(input)}'::json`
-			}
+			json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
+			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` }
 		}, {
 			array: type => `${type}[]`,
+			arrayResolver: (values, piece, resolver) => `array[${values.map(value => resolver(value, piece)).join(', ')}]`,
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
 		});
 		this.db = null;

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -14,7 +14,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` }
 		}, {
 			array: type => `${type}[]`,
-			arrayResolver: (values, piece, resolver) => values.length ? `array[${values.map(value => resolver(value, piece)).join(', ')}]` : '{}',
+			arrayResolver: (values, piece, resolver) => values.length ? `array[${values.map(value => resolver(value, piece)).join(', ')}]` : "'{}'",
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
 		});
 		this.db = null;

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -97,7 +97,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 	/**
 	 * @param {string} table The name of the table to get the data from
 	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*}    [value] The value to filter the data from. Requires the key parameter
+	 * @param {*} [value] The value to filter the data from. Requires the key parameter
 	 * @param {number} [limitMin] The minimum range. Must be higher than zero
 	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
 	 * @returns {Promise<Object[]>}
@@ -105,11 +105,11 @@ module.exports = class PostgreSQL extends SQLProvider {
 	getAll(table, key, value, limitMin, limitMax) {
 		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 ${parseRange(limitMin, limitMax)};`, [value])
-				.then(results => results.map(this.parseEntry.bind(this, table)));
+				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} ${parseRange(limitMin, limitMax)};`)
-			.then(results => results.map(this.parseEntry.bind(this, table)));
+			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 
 	/**
@@ -124,7 +124,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 	/**
 	 * @param {string} table The name of the table to get the data from
 	 * @param {string} key The key to filter the data from
-	 * @param {*}    [value] The value of the filtered key
+	 * @param {*} [value] The value of the filtered key
 	 * @returns {Promise<Object>}
 	 */
 	get(table, key, value) {
@@ -133,7 +133,8 @@ module.exports = class PostgreSQL extends SQLProvider {
 			value = key;
 			key = 'id';
 		}
-		return this.runOne(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 LIMIT 1;`, [value]).then(this.parseEntry.bind(this, table));
+		return this.runOne(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 LIMIT 1;`, [value])
+			.then(output => this.parseEntry(table, output));
 	}
 
 	/**

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -6,14 +6,12 @@ module.exports = class PostgreSQL extends SQLProvider {
 	constructor(...args) {
 		super(...args);
 		this.qb = new QueryBuilder({
-			datatypes: {
-				boolean: { type: 'BOOL' },
-				integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
-				float: { type: 'DOUBLE PRECISION' },
-				uuid: { type: 'UUID' },
-				json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
-				any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` }
-			},
+			boolean: { type: 'BOOL' },
+			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
+			float: { type: 'DOUBLE PRECISION' },
+			uuid: { type: 'UUID' },
+			json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
+			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
 			array: type => `${type}[]`,
 			arrayResolver: (values, piece, resolver) => values.length ? `array[${values.map(value => resolver(value, piece)).join(', ')}]` : "'{}'",
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -1,19 +1,25 @@
-const { Provider, util } = require('klasa');
+const { SQLProvider, Type, Schema, QueryBuilder, util: { mergeDefault, isNumber } } = require('klasa');
 const { Pool } = require('pg');
 
-module.exports = class PostgreSQL extends Provider {
+module.exports = class PostgreSQL extends SQLProvider {
 
 	constructor(...args) {
-		super(...args, {
-			enabled: true,
-			sql: true,
-			description: 'Allows you to use PostgreSQL functionality throught Klasa'
+		super(...args);
+		this.qb = new QueryBuilder({
+			boolean: { type: 'BOOL' },
+			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
+			float: { type: 'DOUBLE PRECISION' },
+			uuid: { type: 'UUID' },
+			any: { type: 'JSON' }
+		}, {
+			array: type => `${type}[]`,
+			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
 		});
 		this.db = null;
 	}
 
 	async init() {
-		const connection = util.mergeDefault({
+		const connection = mergeDefault({
 			host: 'localhost',
 			port: 5432,
 			db: 'klasa',
@@ -156,38 +162,32 @@ module.exports = class PostgreSQL extends Provider {
 	/**
 	 * @param {string} table The name of the table to insert the new data
 	 * @param {string} id The id of the new row to insert
-	 * @param {(string|string[]|{})} param1 The first parameter to validate.
-	 * @param {*} [param2] The second parameter to validate.
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} data The data to update
 	 * @returns {Promise<any[]>}
 	 */
-	insert(table, id, param1, param2) {
-		const [keys, values] = acceptArbitraryInput(param1, param2);
+	create(table, id, data) {
+		const [keys, values] = this.parseUpdateInput(data, false);
 
 		// Push the id to the inserts.
 		keys.push('id');
 		values.push(id);
-		return this.run(`INSERT INTO ${sanitizeKeyName(table)} (${keys.map(sanitizeKeyName).join(', ')}) VALUES (${makeVariables(keys.length)});`, values);
-	}
-
-	/**
-	 * @param {...*} args The arguments
-	 * @alias PostgreSQL#insert
-	 * @returns {Promise<any[]>}
-	 */
-	create(...args) {
-		return this.insert(...args);
+		return this.run(`
+			INSERT INTO ${sanitizeKeyName(table)} (${keys.map(sanitizeKeyName).join(', ')})
+			VALUES (${Array.from({ length: 9 }, (__, i) => `$${i + 1}`).join(', ')});`, values);
 	}
 
 	/**
 	 * @param {string} table The name of the table to update the data from
 	 * @param {string} id The id of the row to update
-	 * @param {(string|string[]|{})} param1 The first parameter to validate.
-	 * @param {*} [param2] The second parameter to validate.
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} data The data to update
 	 * @returns {Promise<any[]>}
 	 */
-	update(table, id, param1, param2) {
-		const [keys, values] = acceptArbitraryInput(param1, param2);
-		return this.run(`UPDATE ${sanitizeKeyName(table)} SET ${keys.map((key, i) => `${sanitizeKeyName(key)} = $${i + 1}`)} WHERE id = ${sanitizeString(id)};`, stringifyArrays(values));
+	update(table, id, data) {
+		const [keys, values] = this.parseUpdateInput(data, false);
+		return this.run(`
+			UPDATE ${sanitizeKeyName(table)}
+			SET ${keys.map((key, i) => `${sanitizeKeyName(key)} = $${i + 1}`)}
+			WHERE id = '${id.replace(/'/, "''")}';`, values);
 	}
 
 	/**
@@ -207,7 +207,7 @@ module.exports = class PostgreSQL extends Provider {
 	 * @returns {Promise<any[]>}
 	 */
 	incrementValue(table, id, key, amount = 1) {
-		if (amount < 0 || isNaN(amount) || Number.isInteger(amount) === false || Number.isSafeInteger(amount) === false) {
+		if (amount < 0 || !isNumber(amount)) {
 			throw new TypeError(`PostgreSQL#incrementValue expects the parameter 'amount' to be an integer greater or equal than zero. Got: ${amount}`);
 		}
 
@@ -222,8 +222,8 @@ module.exports = class PostgreSQL extends Provider {
 	 * @returns {Promise<any[]>}
 	 */
 	decrementValue(table, id, key, amount = 1) {
-		if (amount < 0 || isNaN(amount) || Number.isInteger(amount) === false || Number.isSafeInteger(amount) === false) {
-			throw new TypeError(`PostgreSQL#incrementValue expects the parameter 'amount' to be an integer greater or equal than zero. Got: ${amount}`);
+		if (amount < 0 || !isNumber(amount)) {
+			throw new TypeError(`PostgreSQL#decrementValue expects the parameter 'amount' to be an integer greater or equal than zero. Got: ${amount}`);
 		}
 
 		return this.run(`UPDATE ${sanitizeKeyName(table)} SET $2 = GREATEST(0, $2 - $3) WHERE id = $1;`, [id, key, amount]);
@@ -240,41 +240,38 @@ module.exports = class PostgreSQL extends Provider {
 
 	/**
 	 * Add a new column to a table's schema.
-	 * @param {string} table The name of the table to edit.
-	 * @param {(string|Array<string[]>)} key The key to add.
-	 * @param {string} [datatype] The datatype for the new key.
-	 * @returns {Promise<any[]>}
+	 * @param {string} table The table to check against
+	 * @param {(SchemaFolder | SchemaPiece)} piece The SchemaFolder or SchemaPiece added to the schema
+	 * @returns {Promise<*>}
 	 */
-	addColumn(table, key, datatype) {
-		if (typeof key === 'string') return this.run(`ALTER TABLE ${sanitizeKeyName(table)} ADD COLUMN ${sanitizeKeyName(key)} ${datatype};`);
-		if (typeof datatype === 'undefined' && Array.isArray(key)) {
-			return this.run(`ALTER TABLE ${sanitizeKeyName(table)} ${key.map(([column, type]) =>
-				`ADD COLUMN ${sanitizeKeyName(column)} ${type}`).join(', ')};`);
-		}
-		throw new TypeError('Invalid usage of PostgreSQL#addColumn. Expected a string and string or string[][] and undefined.');
+	addColumn(table, piece) {
+		if (!(piece instanceof Schema)) throw new TypeError('Invalid usage of PostgreSQL#addColumn. Expected a SchemaPiece or SchemaFolder instance.');
+		return this.run(piece.type !== 'Folder' ?
+			`ALTER TABLE ${sanitizeKeyName(table)} ADD COLUMN ${this.qb.parse(piece)};` :
+			`ALTER TABLE ${sanitizeKeyName(table)} ${[...piece.values(true)].map(subpiece => `ADD COLUMN ${this.qb.parse(subpiece)}`).join(', ')}`);
 	}
 
 	/**
 	 * Remove a column from a table's schema.
-	 * @param {string} table The name of the table to edit.
-	 * @param {(string|string[])} key The key to remove.
-	 * @returns {Promise<any[]>}
+	 * @param {string} table The table to check against
+	 * @param {(string|string[])} columns The column names to remove
+	 * @returns {Promise<*>}
 	 */
-	removeColumn(table, key) {
-		if (typeof key === 'string') return this.run(`ALTER TABLE ${sanitizeKeyName(table)} DROP COLUMN ${sanitizeKeyName(key)};`);
-		if (Array.isArray(key)) return this.run(`ALTER TABLE ${sanitizeKeyName(table)} DROP ${key.map(sanitizeKeyName).join(', ')};`);
+	removeColumn(table, columns) {
+		if (typeof columns === 'string') return this.run(`ALTER TABLE ${sanitizeKeyName(table)} DROP COLUMN ${sanitizeKeyName(columns)};`);
+		if (Array.isArray(columns)) return this.run(`ALTER TABLE ${sanitizeKeyName(table)} DROP ${columns.map(sanitizeKeyName).join(', ')};`);
 		throw new TypeError('Invalid usage of PostgreSQL#removeColumn. Expected a string or string[].');
 	}
 
 	/**
-	 * Edit the key's datatype from the table's schema.
-	 * @param {string} table The name of the table to edit.
-	 * @param {string} key The name of the column to update.
-	 * @param {string} datatype The new datatype for the column.
-	 * @returns {Promise<any[]>}
+	 * Alters the datatype from a column.
+	 * @param {string} table The table to check against
+	 * @param {SchemaPiece} piece The modified SchemaPiece
+	 * @returns {Promise<*>}
 	 */
-	updateColumn(table, key, datatype) {
-		return this.run(`ALTER TABLE ${sanitizeKeyName(table)} ALTER ${sanitizeKeyName(key)} TYPE ${datatype};`);
+	updateColumn(table, piece) {
+		const [column, ...datatype] = this.qb.parse(piece).split(' ');
+		return this.run(`ALTER TABLE ${sanitizeKeyName(table)} ALTER ${sanitizeKeyName(column)} TYPE ${datatype};`);
 	}
 
 	/**
@@ -284,8 +281,7 @@ module.exports = class PostgreSQL extends Provider {
 	 */
 	run(...sql) {
 		return this.db.query(...sql)
-			.then(result => result)
-			.catch(error => { throw error; });
+			.then(result => result);
 	}
 
 	/**
@@ -311,123 +307,42 @@ module.exports = class PostgreSQL extends Provider {
 };
 
 /**
-	 * Accept any kind of input from two parameters.
-	 * @param {(string|string[]|{})} param1 The first parameter to validate.
-	 * @param {*} [param2] The second parameter to validate.
-	 * @returns {[[], []]}
-	 * @private
-	 */
-function acceptArbitraryInput(param1, param2) {
-	if (typeof param1 === 'undefined' && typeof param2 === 'undefined') {
-		return [[], []];
-	}
-	if (typeof param1 === 'string' && typeof param2 !== 'undefined') {
-		return [[param1], [param2]];
-	}
-	if (Array.isArray(param1) && Array.isArray(param2)) {
-		if (param1.length !== param2.length) throw new TypeError(`The array lengths do not match: ${param1.length}-${param2.length}`);
-		if (param1.some(value => typeof value !== 'string')) throw new TypeError(`The array of keys must be an array of strings, but found a value that does not match.`);
-		return [param1, param2];
-	}
-	if (util.isObject(param1) && typeof param2 === 'undefined') {
-		const entries = [[], []];
-		getEntriesFromObject(param1, entries, '');
-		return entries;
-	}
-	throw new TypeError('Invalid input. Expected a key type of string and a value, tuple of arrays, or an object and undefined.');
-}
-
-/**
-	 * Get all entries from an object.
-	 * @param {Object} object The object to "flatify".
-	 * @param {[string[], any[]]} param1 The tuple of keys and values to check.
-	 * @param {string} path The current path.
-	 * @private
-	 */
-function getEntriesFromObject(object, [keys, values], path) {
-	const objectKeys = Object.keys(object);
-	for (let i = 0; i < objectKeys.length; i++) {
-		const key = objectKeys[i];
-		const value = object[key];
-		if (util.isObject(value)) {
-			getEntriesFromObject(value, [keys, values], path.length > 0 ? `${path}.${key}` : key);
-		} else {
-			keys.push(path.length > 0 ? `${path}.${key}` : key);
-			values.push(value);
-		}
-	}
-}
-
-/**
-	 * @param {string} value The string to sanitize
-	 * @returns {string}
-	 * @private
-	 */
-function sanitizeString(value) {
-	if (value.length === 0) {
-		throw new TypeError('%PostgreSQL.sanitizeString expects a string with a length bigger than 0.');
-	}
-
-	return `'${value.replace(/'/g, "''")}'`;
-}
-
-/**
-	 * @param {string} value The string to sanitize as a key
-	 * @returns {string}
-	 * @private
-	 */
+ * @param {string} value The string to sanitize as a key
+ * @returns {string}
+ * @private
+ */
 function sanitizeKeyName(value) {
-	if (typeof value !== 'string') {
-		throw new TypeError(`%PostgreSQL.sanitizeString expects a string, got: ${typeof value}`);
-	}
-	if (/`|"/.test(value)) {
-		throw new TypeError(`Invalid input (${value}).`);
-	}
-	if (value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
-		return value;
-	}
+	if (typeof value !== 'string') throw new TypeError(`[SANITIZE_NAME] Expected a string, got: ${new Type(value)}`);
+	if (/`|"/.test(value)) throw new TypeError(`Invalid input (${value}).`);
+	if (value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') return value;
 	return `"${value}"`;
 }
 
 /**
-	 * @param {number} [min] The minimum value
-	 * @param {number} [max] The maximum value
-	 * @returns {string}
-	 * @private
-	 */
+ * @param {number} [min] The minimum value
+ * @param {number} [max] The maximum value
+ * @returns {string}
+ * @private
+ */
 function parseRange(min, max) {
 	// Min value validation
 	if (typeof min === 'undefined') return '';
-	if (isNaN(min) || Number.isInteger(min) === false || Number.isSafeInteger(min) === false) {
-		throw new TypeError(`%PostgreSQL.parseRange 'min' parameter expects an integer or undefined, got ${min}`);
+	if (!isNumber(min)) {
+		throw new TypeError(`[PARSE_RANGE] 'min' parameter expects an integer or undefined, got ${min}`);
 	}
 	if (min < 0) {
-		throw new TypeError(`%PostgreSQL.parseRange 'min' parameter expects to be equal or greater than zero, got ${min}`);
+		throw new RangeError(`[PARSE_RANGE] 'min' parameter expects to be equal or greater than zero, got ${min}`);
 	}
 
 	// Max value validation
 	if (typeof max !== 'undefined') {
-		if (typeof max !== 'number' || isNaN(max) || Number.isInteger(max) === false || Number.isSafeInteger(max) === false) {
-			throw new TypeError(`%PostgreSQL.parseRange 'max' parameter expects an integer or undefined, got ${max}`);
+		if (!isNumber(max)) {
+			throw new TypeError(`[PARSE_RANGE] 'max' parameter expects an integer or undefined, got ${max}`);
 		}
 		if (max <= min) {
-			throw new TypeError(`%PostgreSQL.parseRange 'max' parameter expects ${max} to be greater than ${min}. Got: ${max} <= ${min}`);
+			throw new RangeError(`[PARSE_RANGE] 'max' parameter expects ${max} to be greater than ${min}. Got: ${max} <= ${min}`);
 		}
 	}
 
 	return `LIMIT ${min}${typeof max === 'number' ? `,${max}` : ''}`;
-}
-
-function makeVariables(number) {
-	return new Array(number).fill().map((__, index) => `$${index + 1}`).join(', ');
-}
-
-/**
- * Helper function to stringify arrays correctly
- * @param {Array<*>} array Array out of Arrays where the entries should be stringified
- * @returns {Array<string>}
- */
-function stringifyArrays(array) {
-	for (let index = 0; index < array.length; index++) if (Array.isArray(array[index])) array[index] = JSON.stringify(array[index]);
-	return array;
 }

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -6,13 +6,14 @@ module.exports = class PostgreSQL extends SQLProvider {
 	constructor(...args) {
 		super(...args);
 		this.qb = new QueryBuilder({
-			boolean: { type: 'BOOL' },
-			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
-			float: { type: 'DOUBLE PRECISION' },
-			uuid: { type: 'UUID' },
-			json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
-			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` }
-		}, {
+			datatypes: {
+				boolean: { type: 'BOOL' },
+				integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
+				float: { type: 'DOUBLE PRECISION' },
+				uuid: { type: 'UUID' },
+				json: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` },
+				any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` }
+			},
 			array: type => `${type}[]`,
 			arrayResolver: (values, piece, resolver) => values.length ? `array[${values.map(value => resolver(value, piece)).join(', ')}]` : "'{}'",
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -1,7 +1,7 @@
 const { SQLProvider, Type, Schema, QueryBuilder, util: { mergeDefault, isNumber } } = require('klasa');
 const { Pool } = require('pg');
 
-module.exports = class PostgreSQL extends SQLProvider {
+module.exports = class extends SQLProvider {
 
 	constructor(...args) {
 		super(...args);
@@ -253,7 +253,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 
 	/**
 	 * Add a new column to a table's schema.
-	 * @param {string} table The table to check against
+	 * @param {string} table The table to update
 	 * @param {(SchemaFolder | SchemaPiece)} piece The SchemaFolder or SchemaPiece added to the schema
 	 * @returns {Promise<*>}
 	 */
@@ -266,7 +266,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 
 	/**
 	 * Remove a column from a table's schema.
-	 * @param {string} table The table to check against
+	 * @param {string} table The table to update
 	 * @param {(string|string[])} columns The column names to remove
 	 * @returns {Promise<*>}
 	 */
@@ -278,7 +278,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 
 	/**
 	 * Alters the datatype from a column.
-	 * @param {string} table The table to check against
+	 * @param {string} table The table to update
 	 * @param {SchemaPiece} piece The modified SchemaPiece
 	 * @returns {Promise<*>}
 	 */

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -10,8 +10,16 @@ module.exports = class PostgreSQL extends SQLProvider {
 			integer: { type: ({ max }) => max >= 2 ** 32 ? 'BIGINT' : 'INTEGER' },
 			float: { type: 'DOUBLE PRECISION' },
 			uuid: { type: 'UUID' },
-			json: { type: 'JSON', resolver: (input, { array }) => array ? input.map(value => `'${JSON.stringify(value)}'::json`) : `'${JSON.stringify(input)}'::json` },
-			any: { type: 'JSON', resolver: (input, { array }) => array ? input.map(value => `'${JSON.stringify(value)}'::json`) : `'${JSON.stringify(input)}'::json` }
+			json: {
+				type: 'JSON', resolver: (input, { array }) => array ?
+					`array[${input.map(value => `'${JSON.stringify(value)}'::json`).join(', ')}]` :
+					`'${JSON.stringify(input)}'::json`
+			},
+			any: {
+				type: 'JSON', resolver: (input, { array }) => array ?
+					`array[${input.map(value => `'${JSON.stringify(value)}'::json`).join(', ')}]` :
+					`'${JSON.stringify(input)}'::json`
+			}
 		}, {
 			array: type => `${type}[]`,
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -14,7 +14,7 @@ module.exports = class PostgreSQL extends SQLProvider {
 			any: { type: 'JSON', resolver: (input) => `'${JSON.stringify(input)}'::json` }
 		}, {
 			array: type => `${type}[]`,
-			arrayResolver: (values, piece, resolver) => `array[${values.map(value => resolver(value, piece)).join(', ')}]`,
+			arrayResolver: (values, piece, resolver) => values.length ? `array[${values.map(value => resolver(value, piece)).join(', ')}]` : '{}',
 			formatDatatype: (name, datatype, def = null) => `"${name}" ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`
 		});
 		this.db = null;

--- a/providers/rebirthdb.js
+++ b/providers/rebirthdb.js
@@ -1,14 +1,19 @@
 const { Provider, Type, util: { mergeDefault, isObject, makeObject } } = require('klasa');
-const rethink = require('rethinkdbdash');
+const { r } = require('rebirthdbts'); // eslint-disable-line id-length
 
 module.exports = class extends Provider {
 
 	constructor(...args) {
 		super(...args);
-		this.db = rethink(mergeDefault({
+		this.db = r;
+		this.pool = null;
+	}
+
+	async init() {
+		this.pool = await r.connectPool(mergeDefault({
 			db: 'test',
 			silent: false
-		}, this.client.options.providers.rethinkdb));
+		}, this.client.options.providers.rebirthdb));
 	}
 
 	get exec() {
@@ -22,63 +27,63 @@ module.exports = class extends Provider {
 
 	/* Table methods */
 
-	async hasTable(table) {
+	hasTable(table) {
 		return this.db.tableList().contains(table).run();
 	}
 
-	async createTable(table) {
+	createTable(table) {
 		return this.db.tableCreate(table).run();
 	}
 
-	async deleteTable(table) {
+	deleteTable(table) {
 		return this.db.tableDrop(table).run();
 	}
 
-	async sync(table) {
+	sync(table) {
 		return this.db.table(table).sync().run();
 	}
 
 	/* Document methods */
 
-	async getAll(table, entries = []) {
+	getAll(table, entries = []) {
 		if (entries.length) return this.db.table(table).getAll(...entries).run();
 		return this.db.table(table).run();
 	}
 
-	async getKeys(table, entries = []) {
+	getKeys(table, entries = []) {
 		if (entries.length) return this.db.table(table).getAll(...entries)('id').run();
 		return this.db.table(table).run();
 	}
 
-	async get(table, id) {
+	get(table, id) {
 		return this.db.table(table).get(id).run();
 	}
 
-	async has(table, id) {
+	has(table, id) {
 		return this.db.table(table).get(id).ne(null).run();
 	}
 
-	async getRandom(table) {
+	getRandom(table) {
 		return this.db.table(table).sample(1).run();
 	}
 
-	async create(table, id, value = {}) {
+	create(table, id, value = {}) {
 		return this.db.table(table).insert({ ...this.parseUpdateInput(value), id }).run();
 	}
 
-	async update(table, id, value = {}) {
+	update(table, id, value = {}) {
 		return this.db.table(table).get(id).update(this.parseUpdateInput(value)).run();
 	}
 
-	async replace(table, id, value = {}) {
+	replace(table, id, value = {}) {
 		return this.db.table(table).get(id).replace({ ...this.parseUpdateInput(value), id }).run();
 	}
 
-	async delete(table, id) {
+	delete(table, id) {
 		return this.db.table(table).get(id).delete();
 	}
 
-	async updateValue(table, path, value) {
+	updateValue(table, path, value) {
 		// { channels: { modlog: '340713281972862976' } } | undefined
 		if (isObject(path) && typeof value === 'undefined') {
 			return this.db.table(table).update(path).run();
@@ -89,10 +94,10 @@ module.exports = class extends Provider {
 			return this.db.table(table).update(makeObject(path, value)).run();
 		}
 
-		throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${new Type(path)} and ${new Type(value)}`);
+		return Promise.reject(new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${new Type(path)} and ${new Type(value)}`));
 	}
 
-	async removeValue(table, path) {
+	removeValue(table, path) {
 		// { channels: { modlog: true } }
 		if (isObject(path)) {
 			return this.db.table(table).replace(row => row.without(path)).run();
@@ -104,7 +109,7 @@ module.exports = class extends Provider {
 			return this.db.table(table).replace(row => row.without(rPath)).run();
 		}
 
-		throw new TypeError(`Expected an object or a string as first parameter. Got: ${new Type(path)}`);
+		return Promise.reject(new TypeError(`Expected an object or a string as first parameter. Got: ${new Type(path)}`));
 	}
 
 };

--- a/providers/rebirthdb.js
+++ b/providers/rebirthdb.js
@@ -52,7 +52,7 @@ module.exports = class extends Provider {
 
 	getKeys(table, entries = []) {
 		if (entries.length) return this.db.table(table).getAll(...entries)('id').run();
-		return this.db.table(table).run();
+		return this.db.table(table)('id').run();
 	}
 
 	get(table, id) {

--- a/providers/rebirthdb.js
+++ b/providers/rebirthdb.js
@@ -1,4 +1,4 @@
-const { Provider, Type, util: { mergeDefault, isObject, makeObject } } = require('klasa');
+const { Provider, Type, util: { mergeDefault, isObject, makeObject, chunk } } = require('klasa');
 const { r } = require('rebirthdbts'); // eslint-disable-line id-length
 
 module.exports = class extends Provider {
@@ -45,13 +45,23 @@ module.exports = class extends Provider {
 
 	/* Document methods */
 
-	getAll(table, entries = []) {
-		if (entries.length) return this.db.table(table).getAll(...entries).run();
+	async getAll(table, entries = []) {
+		if (entries.length) {
+			const chunks = chunk(entries, 50000);
+			const output = [];
+			for (const myChunk of chunks) output.push(...await this.db.table(table).getAll(...myChunk).run());
+			return output;
+		}
 		return this.db.table(table).run();
 	}
 
-	getKeys(table, entries = []) {
-		if (entries.length) return this.db.table(table).getAll(...entries)('id').run();
+	async getKeys(table, entries = []) {
+		if (entries.length) {
+			const chunks = chunk(entries, 50000);
+			const output = [];
+			for (const myChunk of chunks) output.push(...await this.db.table(table).getAll(...myChunk)('id').run());
+			return output;
+		}
 		return this.db.table(table)('id').run();
 	}
 

--- a/providers/rebirthdb.js
+++ b/providers/rebirthdb.js
@@ -80,21 +80,7 @@ module.exports = class extends Provider {
 	}
 
 	delete(table, id) {
-		return this.db.table(table).get(id).delete();
-	}
-
-	updateValue(table, path, value) {
-		// { channels: { modlog: '340713281972862976' } } | undefined
-		if (isObject(path) && typeof value === 'undefined') {
-			return this.db.table(table).update(path).run();
-		}
-
-		// 'channels.modlog' | '340713281972862976'
-		if (typeof path === 'string' && typeof value !== 'undefined') {
-			return this.db.table(table).update(makeObject(path, value)).run();
-		}
-
-		return Promise.reject(new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${new Type(path)} and ${new Type(value)}`));
+		return this.db.table(table).get(id).delete().run();
 	}
 
 	removeValue(table, path) {

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -75,21 +75,7 @@ module.exports = class extends Provider {
 	}
 
 	async delete(table, id) {
-		return this.db.table(table).get(id).delete();
-	}
-
-	async updateValue(table, path, value) {
-		// { channels: { modlog: '340713281972862976' } } | undefined
-		if (isObject(path) && typeof value === 'undefined') {
-			return this.db.table(table).update(path).run();
-		}
-
-		// 'channels.modlog' | '340713281972862976'
-		if (typeof path === 'string' && typeof value !== 'undefined') {
-			return this.db.table(table).update(makeObject(path, value)).run();
-		}
-
-		throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${new Type(path)} and ${new Type(value)}`);
+		return this.db.table(table).get(id).delete().run();
 	}
 
 	async removeValue(table, path) {

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -47,7 +47,7 @@ module.exports = class extends Provider {
 
 	async getKeys(table, entries = []) {
 		if (entries.length) return this.db.table(table).getAll(...entries)('id').run();
-		return this.db.table(table).run();
+		return this.db.table(table)('id').run();
 	}
 
 	async get(table, id) {

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -1,4 +1,4 @@
-const { Provider } = require('klasa');
+const { Provider, util: { mergeObjects } } = require('klasa');
 const rethink = require('rethinkdbdash');
 
 module.exports = class extends Provider {
@@ -96,7 +96,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object>}
 	 */
 	getRandom(table) {
-		return this.getAll(table).then(data => data[Math.floor(Math.random() * data.length)]);
+		return this.getKeys(table).then(data => this.get(table, data[Math.floor(Math.random() * data.length)].id));
 	}
 
 	/**
@@ -161,30 +161,22 @@ module.exports = class extends Provider {
 	 * Insert a new document into a table.
 	 * @param {string} table the name of the table.
 	 * @param {string} id the id of the record.
-	 * @param {Object} doc the object you want to insert in the table.
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the object you want to insert in the table.
 	 * @returns {Promise<Object>}
 	 */
 	create(table, id, doc = {}) {
-		return this.db.table(table).insert(Object.assign(doc, { id })).then(resolvePromise);
-	}
-
-	set(...args) {
-		return this.create(...args);
-	}
-
-	insert(...args) {
-		return this.create(...args);
+		return this.db.table(table).insert(mergeObjects(this.parseUpdateInput(doc), { id })).then(resolvePromise);
 	}
 
 	/**
 	 * Update a document from a table given its ID.
 	 * @param {string} table the name of the table.
 	 * @param {string|number} id the entry's ID.
-	 * @param {Object} doc the object you want to insert in the table.
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the object you want to insert in the table.
 	 * @returns {Promise<Object>}
 	 */
 	update(table, id, doc) {
-		return this.db.table(table).get(id).update(doc).then(resolvePromise);
+		return this.db.table(table).get(id).update(this.parseUpdateInput(doc)).then(resolvePromise);
 	}
 
 	/**
@@ -234,11 +226,11 @@ module.exports = class extends Provider {
 	 * Replace the object from an entry with another.
 	 * @param {string} table the name of the table.
 	 * @param {string|number} id the entry's ID.
-	 * @param {Object} doc the document in question to replace the current entry's properties.
+	 * @param {(ConfigurationUpdateResultEntry[] | [string, any][] | Object<string, *>)} doc the document in question to replace the current entry's properties.
 	 * @returns {Promise<Object>}
 	 */
 	replace(table, id, doc) {
-		return this.db.table(table).get(id).replace(doc).then(resolvePromise);
+		return this.db.table(table).get(id).replace(this.parseUpdateInput(doc)).then(resolvePromise);
 	}
 
 	/**

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -1,4 +1,4 @@
-const { Provider, Type, util: { mergeDefault, isObject, makeObject } } = require('klasa');
+const { Provider, Type, util: { mergeDefault, isObject, makeObject, chunk } } = require('klasa');
 const rethink = require('rethinkdbdash');
 
 module.exports = class extends Provider {
@@ -41,12 +41,22 @@ module.exports = class extends Provider {
 	/* Document methods */
 
 	async getAll(table, entries = []) {
-		if (entries.length) return this.db.table(table).getAll(...entries).run();
+		if (entries.length) {
+			const chunks = chunk(entries, 50000);
+			const output = [];
+			for (const myChunk of chunks) output.push(...await this.db.table(table).getAll(...myChunk).run());
+			return output;
+		}
 		return this.db.table(table).run();
 	}
 
 	async getKeys(table, entries = []) {
-		if (entries.length) return this.db.table(table).getAll(...entries)('id').run();
+		if (entries.length) {
+			const chunks = chunk(entries, 50000);
+			const output = [];
+			for (const myChunk of chunks) output.push(...await this.db.table(table).getAll(...myChunk)('id').run());
+			return output;
+		}
 		return this.db.table(table)('id').run();
 	}
 

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -1,10 +1,3 @@
-/**
- * ###################################
- * #             OUTDATED            #
- * # THIS PROVIDER IS NOT UP-TO-DATE #
- * ###################################
- */
-
 const { SQLProvider, QueryBuilder, Type, Timestamp } = require('klasa');
 const { resolve } = require('path');
 const db = require('sqlite');

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -75,13 +75,14 @@ module.exports = class extends SQLProvider {
 	/**
 	 * Get all documents from a table.
 	 * @param {string} table The name of the table to fetch from.
-	 * @param {Object} options key and value.
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, options = {}) {
-		return this.runAll(options.key && options.value ?
-			`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(options.key)} = ${sanitizeValue(options.value)}` :
-			`SELECT * FROM ${sanitizeKeyName(table)}`);
+	getAll(table, entries = []) {
+		if (entries.length) {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}')`);
+		}
+		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
 	}
 
 	/**


### PR DESCRIPTION
Blocked until https://github.com/dirigeants/klasa/pull/284 merges.

**Added**:

- Added **FireStore** provider. (https://github.com/dirigeants/klasa-pieces/pull/64)

**Changed**:

- Edited **PGSQL**, **MSSQL**, **MySQL**, and **SQLite** providers for `QueryBuilder`'s changes.
- Edited **MongoDB**, **RethinkDB**, and **NeDB** providers for `SGv2.2.0`'s changes
- Tweaked `MongoDB#getRandom()` and `RethinkDB#getRandom()` to be much faster.

**Fixed**:

- Fixed **SQLite** provider to be in a functional state (fixed `removeColumn` and `updateColumn`).
- Fixed **LevelDB** provider's indentation.

fixes #21 
fixes #40 