### PR TITLE
getAll() changes in all SQL providers

### DIFF
--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -119,7 +119,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.run(`SELECT * FROM @0 WHERE id IN (@1);`, [table, sanitizeEntries(entries)])
+			return this.run(`SELECT * FROM @0 WHERE id IN (@1);`, [table, `'${entries.join("', '")}'`])
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.run(`SELECT * FROM @0;`, [table])
@@ -298,14 +298,4 @@ function sanitizeKeyName(value) {
 	if (typeof value !== 'string') throw new TypeError(`%MSSQL.sanitizeString expects a string, got: ${new Type(value)}`);
 	if (/`/.test(value)) throw new TypeError(`Invalid input (${value}).`);
 	return value;
-}
-
-/**
-	 *
-	 * @param {array} value The array of entries you want to filter
-	 * @returns {string}
-	 * @private
-	 */
-function sanitizeEntries(value) {
-	return `'${value.join("', '")}'`;
 }

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -117,11 +117,17 @@ module.exports = class extends SQLProvider {
 	 * @param {string} [key] The key to filter the data from. Requires the value parameter
 	 * @param {*} [value] The value to filter the data from. Requires the key parameter
 	 * @param {number} [limit] The maximum range. Must be higher than the limitMin parameter
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limit) {
+	getAll(table, key, value, limit, entries = []) {
 		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
 			return this.run(`SELECT ${parseRange(limit)} * FROM @0 WHERE @1 = @2;`, [table, key, value])
+				.then(results => results.map(output => this.parseEntry(table, output)));
+		}
+
+		if (entries.length > 0) {
+			return this.run(`SELECT ${parseRange(limit)} * FROM @0 WHERE id IN (@1);`, [table, entries.join(',')])
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -119,7 +119,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.run(`SELECT * FROM @0 WHERE id IN (@1);`, [table, entries.join(',')])
+			return this.run(`SELECT * FROM @0 WHERE id IN (@1);`, [table, sanitizeEntries(entries)])
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.run(`SELECT * FROM @0;`, [table])
@@ -298,4 +298,14 @@ function sanitizeKeyName(value) {
 	if (typeof value !== 'string') throw new TypeError(`%MSSQL.sanitizeString expects a string, got: ${new Type(value)}`);
 	if (/`/.test(value)) throw new TypeError(`Invalid input (${value}).`);
 	return value;
+}
+
+/**
+	 *
+	 * @param {array} value The array of entries you want to filter
+	 * @returns {string}
+	 * @private
+	 */
+function sanitizeEntries(value) {
+	return `'${value.join("', '")}'`;
 }

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -126,7 +126,7 @@ module.exports = class extends SQLProvider {
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 
-		if (entries.length > 0) {
+		if (entries.length) {
 			return this.run(`SELECT ${parseRange(limit)} * FROM @0 WHERE id IN (@1);`, [table, entries.join(',')])
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -408,7 +408,7 @@ function sanitizeObject(value) {
  * @private
  */
 function sanitizeBoolean(value) {
-	return Number(value) ? 1 : 0;
+	return value ? 1 : 0;
 }
 
 /**

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -115,7 +115,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${`'${entries.join("', '")}'`});`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}');`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
@@ -408,7 +408,7 @@ function sanitizeObject(value) {
  * @private
  */
 function sanitizeBoolean(value) {
-	return value ? 1 : 0;
+	return Number(value) ? 1 : 0;
 }
 
 /**

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -115,7 +115,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${sanitizeEntries(entries)});`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${`'${entries.join("', '")}'`});`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
@@ -425,14 +425,4 @@ function sanitizeInput(value) {
 		case 'boolean': return sanitizeBoolean(value);
 		default: throw new TypeError(`%MySQL.sanitizeInput expects type of string, number, or object. Got: ${new Type(value)}`);
 	}
-}
-
-/**
-	 *
-	 * @param {array} value The array of entries you want to filter
-	 * @returns {string}
-	 * @private
-	 */
-function sanitizeEntries(value) {
-	return `'${value.join("', '")}'`;
 }

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -114,11 +114,17 @@ module.exports = class extends SQLProvider {
 	 * @param {*} [value] The value to filter the data from. Requires the key parameter
 	 * @param {number} [limitMin] The minimum range. Must be higher than zero
 	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limitMin, limitMax) {
+	getAll(table, key, value, limitMin, limitMax, entries = []) {
 		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = ${sanitizeInput(value)} ${parseRange(limitMin, limitMax)};`)
+				.then(results => results.map(output => this.parseEntry(table, output)));
+		}
+
+		if (entries.length > 0) {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')}) ${parseRange(limitMin, limitMax)};`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -123,7 +123,7 @@ module.exports = class extends SQLProvider {
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 
-		if (entries.length > 0) {
+		if (entries.length) {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')}) ${parseRange(limitMin, limitMax)};`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -115,7 +115,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')});`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${sanitizeEntries(entries)});`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
@@ -425,4 +425,14 @@ function sanitizeInput(value) {
 		case 'boolean': return sanitizeBoolean(value);
 		default: throw new TypeError(`%MySQL.sanitizeInput expects type of string, number, or object. Got: ${new Type(value)}`);
 	}
+}
+
+/**
+	 *
+	 * @param {array} value The array of entries you want to filter
+	 * @returns {string}
+	 * @private
+	 */
+function sanitizeEntries(value) {
+	return `'${value.join("', '")}'`;
 }

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -110,25 +110,15 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*} [value] The value to filter the data from. Requires the key parameter
-	 * @param {number} [limitMin] The minimum range. Must be higher than zero
-	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
 	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limitMin, limitMax, entries = []) {
-		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = ${sanitizeInput(value)} ${parseRange(limitMin, limitMax)};`)
-				.then(results => results.map(output => this.parseEntry(table, output)));
-		}
-
+	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')}) ${parseRange(limitMin, limitMax)};`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')});`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
-
-		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} ${parseRange(limitMin, limitMax)};`)
+		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
 			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -110,7 +110,7 @@ module.exports = class extends SQLProvider {
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 
-		if (entries.length > 0) {
+		if (entries.length) {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')}) ${parseRange(limitMin, limitMax)};`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -102,7 +102,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')});`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${sanitizeEntries(entries)});`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
@@ -354,4 +354,14 @@ function parseRange(min, max) {
 	}
 
 	return `LIMIT ${min}${typeof max === 'number' ? `,${max}` : ''}`;
+}
+
+/**
+	 *
+	 * @param {array} value The array of entries you want to filter
+	 * @returns {string}
+	 * @private
+	 */
+function sanitizeEntries(value) {
+	return `'${value.join("', '")}'`;
 }

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -101,11 +101,17 @@ module.exports = class extends SQLProvider {
 	 * @param {*} [value] The value to filter the data from. Requires the key parameter
 	 * @param {number} [limitMin] The minimum range. Must be higher than zero
 	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limitMin, limitMax) {
+	getAll(table, key, value, limitMin, limitMax, entries = []) {
 		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 ${parseRange(limitMin, limitMax)};`, [value])
+				.then(results => results.map(output => this.parseEntry(table, output)));
+		}
+
+		if (entries.length > 0) {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')}) ${parseRange(limitMin, limitMax)};`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -97,25 +97,15 @@ module.exports = class extends SQLProvider {
 
 	/**
 	 * @param {string} table The name of the table to get the data from
-	 * @param {string} [key] The key to filter the data from. Requires the value parameter
-	 * @param {*} [value] The value to filter the data from. Requires the key parameter
-	 * @param {number} [limitMin] The minimum range. Must be higher than zero
-	 * @param {number} [limitMax] The maximum range. Must be higher than the limitMin parameter
 	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, key, value, limitMin, limitMax, entries = []) {
-		if (typeof key !== 'undefined' && typeof value !== 'undefined') {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = $1 ${parseRange(limitMin, limitMax)};`, [value])
-				.then(results => results.map(output => this.parseEntry(table, output)));
-		}
-
+	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')}) ${parseRange(limitMin, limitMax)};`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${entries.join(',')});`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
-
-		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} ${parseRange(limitMin, limitMax)};`)
+		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
 			.then(results => results.map(output => this.parseEntry(table, output)));
 	}
 

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -102,7 +102,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${`'${entries.join("', '")}'`});`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}');`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -102,7 +102,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${sanitizeEntries(entries)});`)
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${`'${entries.join("', '")}'`});`)
 				.then(results => results.map(output => this.parseEntry(table, output)));
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)};`)
@@ -354,14 +354,4 @@ function parseRange(min, max) {
 	}
 
 	return `LIMIT ${min}${typeof max === 'number' ? `,${max}` : ''}`;
-}
-
-/**
-	 *
-	 * @param {array} value The array of entries you want to filter
-	 * @returns {string}
-	 * @private
-	 */
-function sanitizeEntries(value) {
-	return `'${value.join("', '")}'`;
 }

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -80,7 +80,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ${entries.join(',')}`);
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${sanitizeEntries(entries)})}`);
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
 	}
@@ -301,4 +301,14 @@ function sanitizeValue(value) {
 		case 'object': return value === null ? value : JSON.stringify(value);
 		default: return sanitizeValue(String(value));
 	}
+}
+
+/**
+	 *
+	 * @param {array} value The array of entries you want to filter
+	 * @returns {string}
+	 * @private
+	 */
+function sanitizeEntries(value) {
+	return `'${value.join("', '")}'`;
 }

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -75,19 +75,13 @@ module.exports = class extends SQLProvider {
 	/**
 	 * Get all documents from a table.
 	 * @param {string} table The name of the table to fetch from.
-	 * @param {Object} options key and value.
 	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, options = {}, entries = []) {
-		if (typeof options.key !== 'undefined' && typeof options.value !== 'undefined') {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(options.key)} = ${sanitizeValue(options.value)}`);
-		}
-
+	getAll(table, entries = []) {
 		if (entries.length) {
 			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ${entries.join(',')}`);
 		}
-
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
 	}
 

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -80,7 +80,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${`'${entries.join("', '")}'`})`);
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}')`);
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
 	}

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -80,7 +80,7 @@ module.exports = class extends SQLProvider {
 	 */
 	getAll(table, entries = []) {
 		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${sanitizeEntries(entries)})}`);
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN (${`'${entries.join("', '")}'`})`);
 		}
 		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
 	}
@@ -301,14 +301,4 @@ function sanitizeValue(value) {
 		case 'object': return value === null ? value : JSON.stringify(value);
 		default: return sanitizeValue(String(value));
 	}
-}
-
-/**
-	 *
-	 * @param {array} value The array of entries you want to filter
-	 * @returns {string}
-	 * @private
-	 */
-function sanitizeEntries(value) {
-	return `'${value.join("', '")}'`;
 }

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -76,12 +76,19 @@ module.exports = class extends SQLProvider {
 	 * Get all documents from a table.
 	 * @param {string} table The name of the table to fetch from.
 	 * @param {Object} options key and value.
+	 * @param {array} [entries] Filter the query by getting only the data which is present in the database
 	 * @returns {Promise<Object[]>}
 	 */
-	getAll(table, options = {}) {
-		return this.runAll(options.key && options.value ?
-			`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(options.key)} = ${sanitizeValue(options.value)}` :
-			`SELECT * FROM ${sanitizeKeyName(table)}`);
+	getAll(table, options = {}, entries = []) {
+		if (typeof options.key !== 'undefined' && typeof options.value !== 'undefined') {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(options.key)} = ${sanitizeValue(options.value)}`);
+		}
+
+		if (entries.length) {
+			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ${entries.join(',')}`);
+		}
+
+		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
 	}
 
 	/**


### PR DESCRIPTION
**Description:** This PR enhances the SQL provider's `getAll()` function to work with a new enhancement coming to Klasa SG2.2.0

It'll now filter only the IDs which exist in the database while querying if an array of existing ids are passed.

**Issue:** These providers have not been tested and can not be tested until Klasa#SGv2.2.0 is updated to work with the following providers.