### PR TITLE
Updated all providers for latest SG

### DIFF
--- a/providers/cockroachdb.js
+++ b/providers/cockroachdb.js
@@ -173,6 +173,11 @@ module.exports = class extends SQLProvider {
 		};`);
 	}
 
+	getColumns(table) {
+		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)}`)
+			.then(result => result.map(row => row.column_name));
+	}
+
 	run(...sql) {
 		return this.db.query(...sql)
 			.then(result => result);

--- a/providers/cockroachdb.js
+++ b/providers/cockroachdb.js
@@ -37,7 +37,7 @@ module.exports = class extends SQLProvider {
 			port: connection.port,
 			user: connection.user,
 			password: connection.password,
-			database: connection.db
+			database: connection.database
 		}, connection.options));
 
 		this.db.on('error', error => this.client.emit('error', error));
@@ -174,8 +174,12 @@ module.exports = class extends SQLProvider {
 	}
 
 	getColumns(table) {
-		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)};`)
-			.then(result => result.map(row => row.column_name));
+		return this.runAll(`
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_schema = ${sanitizeKeyName(this.client.options.providers.cockroachdb.database)}
+				AND table_name = ${sanitizeKeyName(table)};`
+		).then(result => result.map(row => row.column_name));
 	}
 
 	run(...sql) {

--- a/providers/cockroachdb.js
+++ b/providers/cockroachdb.js
@@ -174,7 +174,7 @@ module.exports = class extends SQLProvider {
 	}
 
 	getColumns(table) {
-		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)}`)
+		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)};`)
 			.then(result => result.map(row => row.column_name));
 	}
 

--- a/providers/firestore.js
+++ b/providers/firestore.js
@@ -17,8 +17,6 @@
 const { Provider } = require('klasa');
 const firebase = require('firebase-admin');
 
-const { FieldValue } = firebase;
-
 module.exports = class extends Provider {
 
 	constructor(...args) {

--- a/providers/firestore.js
+++ b/providers/firestore.js
@@ -77,19 +77,6 @@ module.exports = class extends Provider {
 		return filter.length ? data.filter(nodes => filter.includes(nodes.id)) : data;
 	}
 
-	async removeValue(table, path) {
-		const keys = await this.getKeys(table);
-
-		if (typeof path === 'object' && typeof newValue === 'undefined') {
-			for (const key of Object.keys(path)) path[key] = FieldValue.deleteValue();
-			await Promise.all(keys.map(doc => this.update(table, doc, path)));
-		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
-			await Promise.all(keys.map(doc => this.update(table, doc, { path: FieldValue.deleteValue() })));
-		} else {
-			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
-		}
-	}
-
 	packData(data, id) {
 		return {
 			...data,
@@ -98,4 +85,3 @@ module.exports = class extends Provider {
 	}
 
 };
-

--- a/providers/level.js
+++ b/providers/level.js
@@ -99,17 +99,4 @@ module.exports = class extends Provider {
 			.then(db => db.delete(document));
 	}
 
-	async removeValue(table, path) {
-		const route = path.split('.');
-		const values = await this.getAll(table);
-		await Promise.all(values.map(object => this._removeValue(table, route, object)));
-	}
-
-	_removeValue(table, route, object) {
-		let value = object;
-		for (let j = 0; j < route.length - 1; j++) value = value[route[j]] || {};
-		delete value[route[route.length - 1]];
-		return this.replace(table, object.id, object);
-	}
-
 };

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -66,23 +66,6 @@ module.exports = class extends Provider {
 		return this.db.collection(table).aggregate({ $sample: { size: 1 } });
 	}
 
-	async removeValue(table, doc) {
-		// { channels: { modlog: true } }
-		if (typeof doc === 'object') {
-			return this.db.table(table).update({}, { $unset: doc }, { multi: true });
-		}
-		// 'channels.modlog'
-		if (typeof doc === 'string') {
-			const route = doc.split('.');
-			const object = {};
-			let ref = object;
-			for (let i = 0; i < route.length - 1; i++) ref = ref[route[i]] = {};
-			ref[route[route.length - 1]] = true;
-			return this.db.table(table).update({}, { $unset: object }, { multi: true });
-		}
-		throw new TypeError(`Expected an object or a string as first parameter. Got: ${typeof doc}`);
-	}
-
 	create(table, id, doc = {}) {
 		return this.db.collection(table).insertOne(mergeObjects(this.parseUpdateInput(doc), resolveQuery(id)));
 	}

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -176,6 +176,14 @@ module.exports = class extends SQLProvider {
 			ALTER COLUMN @1 @2;`, [table, column, datatype]);
 	}
 
+	getColumns(table) {
+		return this.run(`
+			SELECT Field_Name
+			FROM INFORMATION_SCHEMA.COLUMNS
+			WHERE TABLE_NAME = @0
+		`, [table]).map(result => result.map(row => row.Field_Name));
+	}
+
 	run(sql, inputs, outputs) {
 		if (inputs.length > 0) {
 			const request = new mssql.Request();

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -181,7 +181,7 @@ module.exports = class extends SQLProvider {
 			SELECT Field_Name
 			FROM INFORMATION_SCHEMA.COLUMNS
 			WHERE TABLE_NAME = @0
-		`, [table]).map(result => result.map(row => row.Field_Name));
+		`, [table]).then(result => result.map(row => row.Field_Name));
 	}
 
 	run(sql, inputs, outputs) {

--- a/providers/mssql.js
+++ b/providers/mssql.js
@@ -180,7 +180,7 @@ module.exports = class extends SQLProvider {
 		return this.run(`
 			SELECT Field_Name
 			FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = @0
+			WHERE TABLE_NAME = @0;
 		`, [table]).then(result => result.map(row => row.Field_Name));
 	}
 

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -199,8 +199,8 @@ module.exports = class extends SQLProvider {
 		return this.runAll(`
 			SELECT \`COLUMN_NAME\`
 			FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\`
-			WHERE \`TABLE_SCHEMA\` = ${sanitizeKeyName(this.client.options.providers.mysql.database)}
-				AND \`TABLE_NAME\` = ${sanitizeKeyName(table)};
+			WHERE \`TABLE_SCHEMA\` = ${sanitizeString(this.client.options.providers.mysql.database)}
+				AND \`TABLE_NAME\` = ${sanitizeString(table)};
 		`).then(result => result.map(row => row.COLUMN_NAME));
 	}
 

--- a/providers/mysql.js
+++ b/providers/mysql.js
@@ -42,14 +42,14 @@ module.exports = class extends SQLProvider {
 			port: 3306,
 			user: 'root',
 			password: '',
-			db: 'klasa'
+			database: 'klasa'
 		}, this.client.options.providers.mysql);
 		this.db = await mysql.createConnection({
 			host: connection.host,
 			port: connection.port.toString(),
 			user: connection.user,
 			password: connection.password,
-			database: connection.db
+			database: connection.database
 		});
 		this.heartBeatInterval = setInterval(() => {
 			this.db.query('SELECT 1=1')
@@ -193,6 +193,15 @@ module.exports = class extends SQLProvider {
 	updateColumn(table, piece) {
 		const [column, ...datatype] = this.qb.parse(piece).split(' ');
 		return this.exec(`ALTER TABLE ${sanitizeKeyName(table)} MODIFY COLUMN ${sanitizeKeyName(column)} TYPE ${datatype};`);
+	}
+
+	getColumns(table) {
+		return this.runAll(`
+			SELECT \`COLUMN_NAME\`
+			FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\`
+			WHERE \`TABLE_SCHEMA\` = ${sanitizeKeyName(this.client.options.providers.mysql.database)}
+				AND \`TABLE_NAME\` = ${sanitizeKeyName(table)};
+		`).then(result => result.map(row => row.COLUMN_NAME));
 	}
 
 	run(sql) {

--- a/providers/neo4j.js
+++ b/providers/neo4j.js
@@ -1,4 +1,4 @@
-const { Provider, util: { mergeDefault, makeObject, isObject, mergeObjects } } = require('klasa');
+const { Provider, util: { mergeDefault, isObject, mergeObjects } } = require('klasa');
 const { v1: neo4j } = require('neo4j-driver');
 
 module.exports = class extends Provider {

--- a/providers/neo4j.js
+++ b/providers/neo4j.js
@@ -82,17 +82,6 @@ module.exports = class extends Provider {
 		return this.db.run(`MATCH (n:${table} {id : {id} }) SET ${object} RETURN n`, { id });
 	}
 
-	async removeValue(table, path) {
-		const keys = await this.getKeys(table);
-		if (isObject(path) && typeof newValue === 'undefined') {
-			await Promise.all(keys.map(node => this.remove(table, node, path)));
-		} else if (typeof path === 'string' && typeof newValue !== 'undefined') {
-			await Promise.all(keys.map(node => this.remove(table, node, makeObject(path, null))));
-		} else {
-			throw new TypeError(`Expected an object as first parameter or a string and a non-undefined value. Got: ${typeof key} and ${typeof value}`);
-		}
-	}
-
 	async remove(table, id, path) {
 		const [entry] = this.db.run(`MATCH (n:${table} {id: {id} }) RETURN n`, { id }).then(data => data.records.map(node => node._fields[0].properties));
 		Object.keys(path).map(key => delete entry[key]);
@@ -100,4 +89,3 @@ module.exports = class extends Provider {
 	}
 
 };
-

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -172,11 +172,11 @@ module.exports = class extends SQLProvider {
 		};`);
 	}
 
-	getColumns(table) {
+	getColumns(table, schema = 'public') {
 		return this.runAll(`
 			SELECT column_name
 			FROM information_schema.columns
-			WHERE table_schema = ${sanitizeKeyName(this.client.options.providers.postgresql.database)}
+			WHERE table_schema = ${sanitizeKeyName(schema)}
 				AND table_name = ${sanitizeKeyName(table)};
 		`).then(result => result.map(row => row.column_name));
 	}

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -172,6 +172,11 @@ module.exports = class extends SQLProvider {
 		};`);
 	}
 
+	getColumns(table) {
+		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)}`)
+			.then(result => result.map(row => row.column_name));
+	}
+
 	run(...sql) {
 		return this.db.query(...sql)
 			.then(result => result);

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -23,7 +23,7 @@ module.exports = class extends SQLProvider {
 		const connection = mergeDefault({
 			host: 'localhost',
 			port: 5432,
-			db: 'klasa',
+			database: 'klasa',
 			options: {
 				max: 20,
 				idleTimeoutMillis: 30000,
@@ -35,7 +35,7 @@ module.exports = class extends SQLProvider {
 			port: connection.port,
 			user: connection.user,
 			password: connection.password,
-			database: connection.db
+			database: connection.database
 		}, connection.options));
 
 		this.db.on('error', err => this.client.emit('error', err));
@@ -173,8 +173,12 @@ module.exports = class extends SQLProvider {
 	}
 
 	getColumns(table) {
-		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)};`)
-			.then(result => result.map(row => row.column_name));
+		return this.runAll(`
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_schema = ${sanitizeKeyName(this.client.options.providers.postgresql.database)}
+				AND table_name = ${sanitizeKeyName(table)};
+		`).then(result => result.map(row => row.column_name));
 	}
 
 	run(...sql) {

--- a/providers/postgresql.js
+++ b/providers/postgresql.js
@@ -173,7 +173,7 @@ module.exports = class extends SQLProvider {
 	}
 
 	getColumns(table) {
-		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)}`)
+		return this.runAll(`SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ${sanitizeKeyName(table)};`)
 			.then(result => result.map(row => row.column_name));
 	}
 

--- a/providers/rebirthdb.js
+++ b/providers/rebirthdb.js
@@ -93,19 +93,4 @@ module.exports = class extends Provider {
 		return this.db.table(table).get(id).delete().run();
 	}
 
-	removeValue(table, path) {
-		// { channels: { modlog: true } }
-		if (isObject(path)) {
-			return this.db.table(table).replace(row => row.without(path)).run();
-		}
-
-		// 'channels.modlog'
-		if (typeof path === 'string') {
-			const rPath = makeObject(path, true);
-			return this.db.table(table).replace(row => row.without(rPath)).run();
-		}
-
-		return Promise.reject(new TypeError(`Expected an object or a string as first parameter. Got: ${new Type(path)}`));
-	}
-
 };

--- a/providers/rebirthdb.js
+++ b/providers/rebirthdb.js
@@ -1,4 +1,4 @@
-const { Provider, Type, util: { mergeDefault, isObject, makeObject, chunk } } = require('klasa');
+const { Provider, util: { mergeDefault, chunk } } = require('klasa');
 const { r } = require('rebirthdbts'); // eslint-disable-line id-length
 
 module.exports = class extends Provider {

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -88,19 +88,4 @@ module.exports = class extends Provider {
 		return this.db.table(table).get(id).delete().run();
 	}
 
-	async removeValue(table, path) {
-		// { channels: { modlog: true } }
-		if (isObject(path)) {
-			return this.db.table(table).replace(row => row.without(path)).run();
-		}
-
-		// 'channels.modlog'
-		if (typeof path === 'string') {
-			const rPath = makeObject(path, true);
-			return this.db.table(table).replace(row => row.without(rPath)).run();
-		}
-
-		throw new TypeError(`Expected an object or a string as first parameter. Got: ${new Type(path)}`);
-	}
-
 };

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -1,4 +1,4 @@
-const { Provider, Type, util: { mergeDefault, isObject, makeObject, chunk } } = require('klasa');
+const { Provider, util: { mergeDefault, chunk } } = require('klasa');
 const rethink = require('rethinkdbdash');
 
 module.exports = class extends Provider {

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -33,7 +33,7 @@ module.exports = class extends SQLProvider {
 	/* Table methods */
 
 	hasTable(table) {
-		return this.runGet(`SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`)
+		return this.runGet(`SELECT name FROM sqlite_master WHERE type='table' AND name='${table}';`)
 			.then(Boolean);
 	}
 
@@ -46,39 +46,38 @@ module.exports = class extends SQLProvider {
 		return this.run(`
 			CREATE TABLE ${sanitizeKeyName(table)} (
 				id VARCHAR(18) PRIMARY KEY NOT NULL UNIQUE${schemaValues.length ? `, ${schemaValues.map(this.qb.parse.bind(this.qb)).join(', ')}` : ''}
-			)`
+			);`
 		);
 	}
 
 	deleteTable(table) {
-		return this.run(`DROP TABLE ${sanitizeKeyName(table)}`);
+		return this.run(`DROP TABLE ${sanitizeKeyName(table)};`);
 	}
 
 	/* Document methods */
 
 	getAll(table, entries = []) {
-		if (entries.length) {
-			return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}')`);
-		}
-		return this.runAll(`SELECT * FROM ${sanitizeKeyName(table)}`);
+		return this.runAll(entries.length ?
+			`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}');` :
+			`SELECT * FROM ${sanitizeKeyName(table)};`);
 	}
 
 	get(table, key, value = null) {
 		return this.runGet(value === null ?
-			`SELECT * FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeKeyName(key)}` :
-			`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = ${sanitizeValue(value)}`)
+			`SELECT * FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeKeyName(key)};` :
+			`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = ${sanitizeValue(value)};`)
 			.then(output => this.parseEntry(table, output))
 			.catch(() => null);
 	}
 
 	has(table, key) {
-		return this.runGet(`SELECT id FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeValue(key)}`)
+		return this.runGet(`SELECT id FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeValue(key)};`)
 			.then(() => true)
 			.catch(() => false);
 	}
 
 	getRandom(table) {
-		return this.runGet(`SELECT * FROM ${sanitizeKeyName(table)} ORDER BY RANDOM() LIMIT 1`)
+		return this.runGet(`SELECT * FROM ${sanitizeKeyName(table)} ORDER BY RANDOM() LIMIT 1;`)
 			.then(output => this.parseEntry(table, output))
 			.catch(() => null);
 	}
@@ -89,7 +88,7 @@ module.exports = class extends SQLProvider {
 		// Push the id to the inserts.
 		keys.push('id');
 		values.push(id);
-		return this.run(`INSERT INTO ${sanitizeKeyName(table)} ( ${keys.map(sanitizeKeyName).join(', ')} ) VALUES ( ${values.map(sanitizeValue).join(', ')} )`);
+		return this.run(`INSERT INTO ${sanitizeKeyName(table)} ( ${keys.map(sanitizeKeyName).join(', ')} ) VALUES ( ${values.map(sanitizeValue).join(', ')} );`);
 	}
 
 	update(table, id, data) {
@@ -97,7 +96,7 @@ module.exports = class extends SQLProvider {
 		return this.run(`
 			UPDATE ${sanitizeKeyName(table)}
 			SET ${keys.map((key, i) => `${sanitizeKeyName(key)} = ${sanitizeValue(values[i])}`)}
-			WHERE id = ${sanitizeValue(id)}`);
+			WHERE id = ${sanitizeValue(id)};`);
 	}
 
 	replace(...args) {
@@ -105,11 +104,11 @@ module.exports = class extends SQLProvider {
 	}
 
 	delete(table, row) {
-		return this.run(`DELETE FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeValue(row)}`);
+		return this.run(`DELETE FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeValue(row)};`);
 	}
 
 	addColumn(table, piece) {
-		return this.exec(`ALTER TABLE ${sanitizeKeyName(table)} ADD ${sanitizeKeyName(piece.key)} ${piece.type}`);
+		return this.exec(`ALTER TABLE ${sanitizeKeyName(table)} ADD ${sanitizeKeyName(piece.key)} ${piece.type};`);
 	}
 
 	async removeColumn(table, schemaPiece) {
@@ -132,10 +131,10 @@ module.exports = class extends SQLProvider {
 		await this.exec([
 			`INSERT INTO ${sanitizedCloneTable} (${filteredPiecesNames})`,
 			`	SELECT ${filteredPiecesNames}`,
-			`	FROM ${sanitizedTable}`
+			`	FROM ${sanitizedTable};`
 		].join('\n'));
-		await this.exec(`DROP TABLE ${sanitizedTable}`);
-		await this.exec(`ALTER TABLE ${sanitizedCloneTable} RENAME TO ${sanitizedTable}`);
+		await this.exec(`DROP TABLE ${sanitizedTable};`);
+		await this.exec(`ALTER TABLE ${sanitizedCloneTable} RENAME TO ${sanitizedTable};`);
 		return true;
 	}
 
@@ -158,15 +157,15 @@ module.exports = class extends SQLProvider {
 		await this.exec([
 			`INSERT INTO ${sanitizedCloneTable} (${allPiecesNames})`,
 			`	SELECT ${allPiecesNames}`,
-			`	FROM ${sanitizedTable}`
+			`	FROM ${sanitizedTable};`
 		].join('\n'));
-		await this.exec(`DROP TABLE ${sanitizedTable}`);
-		await this.exec(`ALTER TABLE ${sanitizedCloneTable} RENAME TO ${sanitizedTable}`);
+		await this.exec(`DROP TABLE ${sanitizedTable};`);
+		await this.exec(`ALTER TABLE ${sanitizedCloneTable} RENAME TO ${sanitizedTable};`);
 		return true;
 	}
 
 	getColumns(table) {
-		return this.runAll(`PRAGMA table_info(${sanitizeKeyName(table)})`)
+		return this.runAll(`PRAGMA table_info(${sanitizeKeyName(table)});`)
 			.then(result => result.map(row => row.name));
 	}
 

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -165,6 +165,11 @@ module.exports = class extends SQLProvider {
 		return true;
 	}
 
+	getColumns(table) {
+		return this.runAll(`PRAGMA table_info(${sanitizeKeyName(table)})`)
+			.then(result => result.map(row => row.name));
+	}
+
 	// Get a row from an arbitrary SQL query.
 	runGet(sql) {
 		return db.get(sql);

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -59,14 +59,15 @@ module.exports = class extends SQLProvider {
 	getAll(table, entries = []) {
 		return this.runAll(entries.length ?
 			`SELECT * FROM ${sanitizeKeyName(table)} WHERE id IN ('${entries.join("', '")}');` :
-			`SELECT * FROM ${sanitizeKeyName(table)};`);
+			`SELECT * FROM ${sanitizeKeyName(table)};`)
+			.then(output => output.map(entry => this.parseEntry(table, entry)));
 	}
 
 	get(table, key, value = null) {
 		return this.runGet(value === null ?
 			`SELECT * FROM ${sanitizeKeyName(table)} WHERE id = ${sanitizeKeyName(key)};` :
 			`SELECT * FROM ${sanitizeKeyName(table)} WHERE ${sanitizeKeyName(key)} = ${sanitizeValue(value)};`)
-			.then(output => this.parseEntry(table, output))
+			.then(entry => this.parseEntry(table, entry))
 			.catch(() => null);
 	}
 
@@ -78,7 +79,7 @@ module.exports = class extends SQLProvider {
 
 	getRandom(table) {
 		return this.runGet(`SELECT * FROM ${sanitizeKeyName(table)} ORDER BY RANDOM() LIMIT 1;`)
-			.then(output => this.parseEntry(table, output))
+			.then(entry => this.parseEntry(table, entry))
 			.catch(() => null);
 	}
 

--- a/providers/sqlite.js
+++ b/providers/sqlite.js
@@ -109,7 +109,7 @@ module.exports = class extends SQLProvider {
 	}
 
 	addColumn(table, piece) {
-		return this.exec(`ALTER TABLE ${sanitizeKeyName(table)} ADD ${sanitizeKeyName(piece.key)} ${piece.type};`);
+		return this.exec(`ALTER TABLE ${sanitizeKeyName(table)} ADD ${sanitizeKeyName(piece.path)} ${piece.type};`);
 	}
 
 	async removeColumn(table, schemaPiece) {


### PR DESCRIPTION
PR required for the functionality of https://github.com/dirigeants/klasa/pull/383

Providers updated:

- [x] CockroachDB (Added getColumns)
- [x] FireStore (Removed removeValue)
- [x] Level (Removed removeValue)
- [x] MongoDB (Removed removeValue)
- [x] MSSQL (Added getColumns)
- [x] MySQL (Added getColumns, thanks @AdityaTD)
- [x] NeDB (No changes required)
- [x] Neo4J (Removed removeValue)
- [x] PostgreSQL (Added getColumns, thanks @Dev-Yukine)
- [x] RebirthDB (Removed removeValue)
- [x] RethinkDB (Removed removeValue)
- [x] SQLite (Added getColumns)