### PR TITLE
Fix rethinkdb provider

### DIFF
--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -21,7 +21,7 @@ module.exports = class extends Provider {
 	}
 
 	async shutdown() {
-		return this.connection.getPoolMaster().drain();
+		return this.db.getPoolMaster().drain();
 	}
 
 	/* Table methods */


### PR DESCRIPTION
Fixes a typo in the rethinkdb provider where the shutdown method was using `this.connection`