### PR TITLE
fix: mongodb - update overwrites data in SchemaFolders

### DIFF
--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -87,16 +87,16 @@ module.exports = class extends Provider {
 const resolveQuery = query => isObject(query) ? query : { id: query };
 
 const parseUpdateObject = (doc, pref = '', oldObj = {}) => {
-  const obj = oldObj;
-  const prefix = pref !== '' ? `${pref}.` : '';
-  for (const key in doc) {
-    if (Object.prototype.hasOwnProperty.call(doc, key)) {
-      if (typeof doc[key] !== 'object' || Object.keys(doc[key]).length === 0) {
-        obj[`${prefix}${key}`] = doc[key];
-        continue;
-      }
-      parseUpdateObject(doc[key], `${prefix}${key}`, obj);
-    }
-  }
-  return obj;
+	const obj = oldObj;
+	const prefix = pref !== '' ? `${pref}.` : '';
+	for (const key in doc) {
+		if (Object.prototype.hasOwnProperty.call(doc, key)) {
+			if (typeof doc[key] !== 'object' || Object.keys(doc[key]).length === 0) {
+				obj[`${prefix}${key}`] = doc[key];
+				continue;
+			}
+			parseUpdateObject(doc[key], `${prefix}${key}`, obj);
+		}
+  	}
+  	return obj;
 };

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -75,7 +75,7 @@ module.exports = class extends Provider {
 	}
 
 	update(table, id, doc) {
-		return this.db.collection(table).updateOne(resolveQuery(id), { $set: this.parseUpdateInput(doc) });
+		return this.db.collection(table).updateOne(resolveQuery(id), { $set: parseUpdateObject(this.parseUpdateInput(doc)) });
 	}
 
 	replace(table, id, doc) {
@@ -85,3 +85,18 @@ module.exports = class extends Provider {
 };
 
 const resolveQuery = query => isObject(query) ? query : { id: query };
+
+const parseUpdateObject = (doc, pref = '', oldObj = {}) => {
+  const obj = oldObj;
+  const prefix = pref !== '' ? `${pref}.` : '';
+  for (const key in doc) {
+    if (Object.prototype.hasOwnProperty.call(doc, key)) {
+      if (typeof doc[key] !== 'object' || Object.keys(doc[key]).length === 0) {
+        obj[`${prefix}${key}`] = doc[key];
+        continue;
+      }
+      parseObject(doc[key], `${prefix}${key}`, obj);
+    }
+  }
+  return obj;
+};

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -75,7 +75,7 @@ module.exports = class extends Provider {
 	}
 
 	update(table, id, doc) {
-		return this.db.collection(table).updateOne(resolveQuery(id), { $set: isObject(doc) ? flatten(doc) : parseEngineInput(updated) });
+		return this.db.collection(table).updateOne(resolveQuery(id), { $set: isObject(doc) ? flatten(doc) : parseEngineInput(doc.updated) });
 	}
 
 	replace(table, id, doc) {
@@ -87,14 +87,14 @@ module.exports = class extends Provider {
 const resolveQuery = query => isObject(query) ? query : { id: query };
 
 function flatten(obj, path = '') {
-    let output = {};
-    for (const [key, value] of Object.entries(obj)) {
-        if (isObject(value)) output = Object.assign(output, flatten(value, path ? `${path}.${key}` : key));
-        else output[path ? `${path}.${key}` : key] = value;
-    }
-    return output;
+	let output = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (isObject(value)) output = Object.assign(output, flatten(value, path ? `${path}.${key}` : key));
+		else output[path ? `${path}.${key}` : key] = value;
+	}
+	return output;
 }
 
 function parseEngineInput(updated) {
-    return Object.assign({}, ...updated.map(entry => ({ [entry.data[0]]: entry.data[1] })));
+	return Object.assign({}, ...updated.map(entry => ({ [entry.data[0]]: entry.data[1] })));
 }

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -75,7 +75,7 @@ module.exports = class extends Provider {
 	}
 
 	update(table, id, doc) {
-		return this.db.collection(table).updateOne(resolveQuery(id), { $set: parseUpdateObject(this.parseUpdateInput(doc)) });
+		return this.db.collection(table).updateOne(resolveQuery(id), { $set: isObject(doc) ? flatten(doc) : parseEngineInput(updated) });
 	}
 
 	replace(table, id, doc) {
@@ -86,17 +86,15 @@ module.exports = class extends Provider {
 
 const resolveQuery = query => isObject(query) ? query : { id: query };
 
-const parseUpdateObject = (doc, pref = '', oldObj = {}) => {
-	const obj = oldObj;
-	const prefix = pref !== '' ? `${pref}.` : '';
-	for (const key in doc) {
-		if (Object.prototype.hasOwnProperty.call(doc, key)) {
-			if (isObject(doc[key]) || Object.keys(doc[key]).length === 0) {
-				obj[`${prefix}${key}`] = doc[key];
-				continue;
-			}
-			parseUpdateObject(doc[key], `${prefix}${key}`, obj);
-		}
-	}
-	return obj;
-};
+function flatten(obj, path = '') {
+    let output = {};
+    for (const [key, value] of Object.entries(obj)) {
+        if (isObject(value)) output = Object.assign(output, flatten(value, path ? `${path}.${key}` : key));
+        else output[path ? `${path}.${key}` : key] = value;
+    }
+    return output;
+}
+
+function parseEngineInput(updated) {
+    return Object.assign({}, ...updated.map(entry => ({ [entry.data[0]]: entry.data[1] })));
+}

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -97,6 +97,6 @@ const parseUpdateObject = (doc, pref = '', oldObj = {}) => {
 			}
 			parseUpdateObject(doc[key], `${prefix}${key}`, obj);
 		}
-  	}
-  	return obj;
+	}
+	return obj;
 };

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -95,7 +95,7 @@ const parseUpdateObject = (doc, pref = '', oldObj = {}) => {
         obj[`${prefix}${key}`] = doc[key];
         continue;
       }
-      parseObject(doc[key], `${prefix}${key}`, obj);
+      parseUpdateObject(doc[key], `${prefix}${key}`, obj);
     }
   }
   return obj;

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -91,7 +91,7 @@ const parseUpdateObject = (doc, pref = '', oldObj = {}) => {
 	const prefix = pref !== '' ? `${pref}.` : '';
 	for (const key in doc) {
 		if (Object.prototype.hasOwnProperty.call(doc, key)) {
-			if (typeof doc[key] !== 'object' || Object.keys(doc[key]).length === 0) {
+			if (isObject(doc[key]) || Object.keys(doc[key]).length === 0) {
 				obj[`${prefix}${key}`] = doc[key];
 				continue;
 			}


### PR DESCRIPTION
With the current parseUpdateInput, mongodb overwrites the whole object for SchemaFolders.
This PR adds an object to dot notation parser to fix this.