### PR TITLE
fix: await the creation of the database if missing

### DIFF
--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -13,8 +13,7 @@ module.exports = class extends Provider {
 
 	async init() {
 		const { db } = this.db._poolMaster._options;
-		await this.db.branch(this.db.dbList().contains(db), null, this.db.dbCreate(db));
-		return null;
+		await this.db.branch(this.db.dbList().contains(db), null, this.db.dbCreate(db)).run();
 	}
 
 	get exec() {

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -13,7 +13,8 @@ module.exports = class extends Provider {
 
 	async init() {
 		const { db } = this.db._poolMaster._options;
-		return await this.db.branch(this.db.dbList().contains(db), null, this.db.dbCreate(db));
+		await this.db.branch(this.db.dbList().contains(db), null, this.db.dbCreate(db));
+		return null;
 	}
 
 	get exec() {

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -13,7 +13,7 @@ module.exports = class extends Provider {
 
 	async init() {
 		const { db } = this.db._poolMaster._options;
-		return this.db.branch(this.db.dbList().contains(db), null, this.db.dbCreate(db));
+		return await this.db.branch(this.db.dbList().contains(db), null, this.db.dbCreate(db));
 	}
 
 	get exec() {


### PR DESCRIPTION
This fixes a race condition where the db doesn't exist if someone uses rethinkdb manually too