### PR TITLE
add: user auth in the RethinkDB provider

### DIFF
--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -7,6 +7,8 @@ module.exports = class extends Provider {
 		super(...args);
 		this.db = rethink(mergeDefault({
 			db: 'test',
+			user: 'admin',
+			password: '',
 			silent: false
 		}, this.client.options.providers.rethinkdb));
 	}


### PR DESCRIPTION
I added the auth attributes "user" and "password".
I spent some time to look up how to authenticate with "rethinkdbash" so I thought it would be easier for other users of this provider to instantly see what's going on. I also added the default credentials for the admin user which are usually admin:''.

If this is redundant deny the PR and close :)