### PR TITLE
better roleinfo timestamp

### DIFF
--- a/commands/Tools/role-info.js
+++ b/commands/Tools/role-info.js
@@ -38,7 +38,7 @@ module.exports = class extends Command {
 			MOVE_MEMBERS: 'Move Members',
 			USE_VAD: 'Use Voice Activity'
 		};
-		this.timestamp = new Timestamp('MMMM dd YYYY');
+		this.timestamp = new Timestamp('dddd, MMMM d YYYY');
 	}
 
 	run(msg, [role]) {


### PR DESCRIPTION
The current timestamp displays as "Thursday, October 2017" which is quite useless. This update makes it "Monday, December 12th 2016", much more informative.