### PR TITLE
Add Spotify commands

### DIFF
--- a/commands/Tools/artist.js
+++ b/commands/Tools/artist.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			cooldown: 10,
-			description: 'Searches Spotify for a song, and returns an embeddable link.',
+			description: 'Searches Spotify for an artist, and returns an embed.',
 			usage: '<query:str{1,100}>'
 		});
 	}
@@ -17,7 +17,7 @@ module.exports = class extends Command {
 			throw 'Missing access token for Spotify. Please try again in a few minutes.';
 		}
 
-		const song = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=1`,
+		const artist = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=artist&limit=1`,
 			{
 				headers: {
 					Accept: 'application/json',
@@ -26,11 +26,11 @@ module.exports = class extends Command {
 				}
 			})
 			.then(response => response.json())
-			.then(response => response.tracks.items[0])
+			.then(response => response.artists.items[0])
 			.catch(() => { throw 'There was an error. Please try again later.'; });
 
-		if (!song) throw "Couldn't find any songs with that name.";
-		return msg.sendMessage(song.external_urls.spotify);
+		if (!artist) throw "Couldn't find any artists with that name.";
+		return msg.sendMessage(artist.external_urls.spotify);
 	}
 
 };

--- a/commands/Tools/artist.js
+++ b/commands/Tools/artist.js
@@ -1,4 +1,8 @@
-// Requires getSpotifyToken task
+/*
+*    Requires getSpotifyToken task
+*    https://github.com/dirigeants/klasa-pieces/blob/master/tasks/getSpotifyToken.js
+*
+*/
 const { Command } = require('klasa');
 const fetch = require('node-fetch');
 
@@ -13,9 +17,7 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [query]) {
-		if (!this.client._spotifyToken) {
-			throw 'Missing access token for Spotify. Please try again in a few minutes.';
-		}
+		if (!this.client._spotifyToken) return this.client.emit('wtf', 'Spotify Token is undefined.');
 
 		const artist = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=artist&limit=1`,
 			{
@@ -29,8 +31,8 @@ module.exports = class extends Command {
 			.then(response => response.artists.items[0])
 			.catch(() => { throw 'There was an error. Please try again later.'; });
 
-		if (!artist) throw "Couldn't find any artists with that name.";
-		return msg.sendMessage(artist.external_urls.spotify);
+		if (artist) return msg.sendMessage(artist.external_urls.spotify);
+		throw "Couldn't find any artists with that name.";
 	}
 
 };

--- a/commands/Tools/artist.js
+++ b/commands/Tools/artist.js
@@ -1,3 +1,4 @@
+// Copyright (c) 2017-2018 dirigeants. All rights reserved. MIT license.
 /*
 *    Requires getSpotifyToken task
 *    https://github.com/dirigeants/klasa-pieces/blob/master/tasks/getSpotifyToken.js

--- a/commands/Tools/song.js
+++ b/commands/Tools/song.js
@@ -1,3 +1,4 @@
+// Copyright (c) 2017-2018 dirigeants. All rights reserved. MIT license.
 /*
 *    Requires getSpotifyToken task
 *    https://github.com/dirigeants/klasa-pieces/blob/master/tasks/getSpotifyToken.js

--- a/commands/Tools/song.js
+++ b/commands/Tools/song.js
@@ -1,4 +1,8 @@
-// Requires getSpotifyToken task
+/*
+*    Requires getSpotifyToken task
+*    https://github.com/dirigeants/klasa-pieces/blob/master/tasks/getSpotifyToken.js
+*
+*/
 const { Command } = require('klasa');
 const fetch = require('node-fetch');
 
@@ -13,9 +17,7 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [query]) {
-		if (!this.client._spotifyToken) {
-			throw 'Missing access token for Spotify. Please try again in a few minutes.';
-		}
+		if (!this.client._spotifyToken) return this.client.emit('wtf', 'Spotify Token is undefined.');
 
 		const song = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=1`,
 			{
@@ -29,8 +31,8 @@ module.exports = class extends Command {
 			.then(response => response.tracks.items[0])
 			.catch(() => { throw 'There was an error. Please try again later.'; });
 
-		if (!song) throw "Couldn't find any songs with that name.";
-		return msg.sendMessage(song.external_urls.spotify);
+		if (song) return msg.sendMessage(song.external_urls.spotify);
+		throw "Couldn't find any songs with that name.";
 	}
 
 };

--- a/commands/Tools/song.js
+++ b/commands/Tools/song.js
@@ -1,0 +1,35 @@
+// Requires getSpotifyToken task
+const { Command } = require('klasa');
+const fetch = require('node-fetch');
+
+module.exports = class extends Command {
+
+	constructor(...args) {
+		super(...args, {
+			cooldown: 10,
+			description: 'Searches Spotify for a song, and returns an embeddable link.',
+			usage: '<query:str{1,100}>'
+		});
+	}
+
+	async run(msg, [query]) {
+		if (!this.client._spotifyToken) {
+			throw 'Missing access token for Spotify. Please try again in a few minutes.';
+		}
+
+		const song = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=1`,
+			{
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${this.client._spotifyToken}`
+				}
+			})
+			.then(response => response.json())
+			.then(response => response.tracks.items[0])
+			.catch(() => { throw "Couldn't find any songs with that name."; });
+
+		return msg.sendMessage(song.external_urls.spotify);
+	}
+
+};

--- a/tasks/getSpotifyToken.js
+++ b/tasks/getSpotifyToken.js
@@ -1,0 +1,38 @@
+const { Task } = require('klasa');
+const fetch = require('node-fetch');
+
+// Login to https://developer.spotify.com/dashboard/applications
+// Create an app & get your clientID/secret, place them below
+// Run every 1 hour to refresh: this.client.schedule.create("getSpotifyToken", "*/60 * * * *")
+const clientID = '';
+const clientSecret = '';
+
+const authorization = Buffer.from(`${clientID}:${clientSecret}`).toString('base64');
+
+module.exports = class extends Task {
+
+	async run() {
+		this._getToken();
+	}
+
+	async init() {
+		this._getToken();
+	}
+
+	async _getToken() {
+		const accessToken = await fetch(`https://accounts.spotify.com/api/token`, {
+			method: 'POST',
+			body: 'grant_type=client_credentials',
+			headers: {
+				Authorization: `Basic ${authorization}`,
+				'Content-Type': 'application/x-www-form-urlencoded'
+			}
+		})
+			.then(response => response.json())
+			.then(response => response.access_token)
+			.catch(console.error);
+
+		this.client._spotifyToken = accessToken;
+	}
+
+};

--- a/tasks/getSpotifyToken.js
+++ b/tasks/getSpotifyToken.js
@@ -1,3 +1,4 @@
+// Copyright (c) 2017-2018 dirigeants. All rights reserved. MIT license.
 const { Task } = require('klasa');
 const fetch = require('node-fetch');
 


### PR DESCRIPTION
getSpotifyToken Task: With the developers client ID and client secret, it will fetch an access token for a client application which will allow them to access the spotify API. It stores the access token in `client._spotifyToken` (although the developer can move it to where they want, the tokens expire and dont need to be stored persistently)

song/artist command will search the spotify API for a song/artist with a query given by the user, using the access token retrieved from the task.

