### PR TITLE
add messagepromise serializer

### DIFF
--- a/serializers/messagepromise.js
+++ b/serializers/messagepromise.js
@@ -1,0 +1,37 @@
+const { Message } = require('discord.js');
+const { Serializer } = require('klasa');
+
+module.exports = class extends Serializer {
+
+	deserialize(data, piece, language, guild) {
+		if (data instanceof Message) return data;
+		if (typeof data !== 'string') throw this.constructor.error(language, piece.key);
+		const [channelID, messageID] = data.split('/', 2);
+		if (!(channelID && messageID)) throw this.constructor.error(language, piece.key);
+
+		const channel = this.client.serializers.get('channel').deserialize(channelID,
+			{ key: piece.key, type: 'textchannel' }, language, guild);
+		const messagePromise = this.constructor.regex.snowflake.test(messageID) ? channel.messages.fetch(messageID) : null;
+		if (messagePromise) return messagePromise;
+		// Yes, the split is supposed to be text, not code
+		throw language.get('RESOLVER_INVALID_MESSAGE', `${piece.key}.split('/')[1]`);
+	}
+
+	serialize(data) {
+		return `${data.channel.id}/${data.id}`;
+	}
+
+	stringify(data, channel) {
+		// channel might be a message, I sure as heck don't know
+		return ((channel.messages || channel.channel.messages).get(data) || { content: (data && data.content) || data }).content;
+	}
+
+	static error(language, name) {
+		// Yes, the split is supposed to be text, not code
+		return [
+			language.get('RESOLVER_INVALID_CHANNEL', `${name}.split('/')[0]`),
+			language.get('RESOLVER_INVALID_MESSAGE', `${name}.split('/')[1]`)
+		].join(' ');
+	}
+
+};


### PR DESCRIPTION
Adds a serializer for messages. Since most of the time this requires fetching, it returns a promise (specifically, `Promise<KlasaMessage>`). It stores messages as "channel ID/message ID", similar to how links to messages work on Discord.

I'm not sure about how it does the error messages, with the `${piece.key}.split('/')[1]`, but I felt that was the clearest way to specify what was wrong with the input.