### PR TITLE
Update prefix.js

### DIFF
--- a/commands/Configuration/prefix.js
+++ b/commands/Configuration/prefix.js
@@ -16,7 +16,7 @@ module.exports = class extends Command {
 
 	async run(message, [prefix]) {
 		if (!prefix) return message.send(`The prefix for this guild is \`${message.guild.settings.prefix}\``);
-    		if(!await message.hasAtLeastPermissionLevel(6)) throw message.language.get('INHIBITOR_PERMISSIONS');
+		if(!await message.hasAtLeastPermissionLevel(6)) throw message.language.get('INHIBITOR_PERMISSIONS');
 		if (prefix === 'reset') return this.reset(message);
 		if (message.guild.settings.prefix === prefix) throw message.language.get('CONFIGURATION_EQUALS');
 		await message.guild.settings.update('prefix', prefix);

--- a/commands/Configuration/prefix.js
+++ b/commands/Configuration/prefix.js
@@ -16,7 +16,7 @@ module.exports = class extends Command {
 
 	async run(message, [prefix]) {
 		if (!prefix) return message.send(`The prefix for this guild is \`${message.guild.settings.prefix}\``);
-		if(!await message.hasAtLeastPermissionLevel(6)) throw message.language.get('INHIBITOR_PERMISSIONS');
+		if (!await message.hasAtLeastPermissionLevel(6)) throw message.language.get('INHIBITOR_PERMISSIONS');
 		if (prefix === 'reset') return this.reset(message);
 		if (message.guild.settings.prefix === prefix) throw message.language.get('CONFIGURATION_EQUALS');
 		await message.guild.settings.update('prefix', prefix);

--- a/commands/Configuration/prefix.js
+++ b/commands/Configuration/prefix.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 			aliases: ['setPrefix'],
 			cooldown: 5,
 			description: 'Change the command prefix the bot uses in your server.',
-			permissionLevel: 6,
+			permissionLevel: 0,
 			runIn: ['text'],
 			usage: '[reset|prefix:str{1,10}]'
 		});
@@ -16,6 +16,7 @@ module.exports = class extends Command {
 
 	async run(message, [prefix]) {
 		if (!prefix) return message.send(`The prefix for this guild is \`${message.guild.settings.prefix}\``);
+    		if(!await message.hasAtLeastPermissionLevel(6)) throw message.language.get('INHIBITOR_PERMISSIONS');
 		if (prefix === 'reset') return this.reset(message);
 		if (message.guild.settings.prefix === prefix) throw message.language.get('CONFIGURATION_EQUALS');
 		await message.guild.settings.update('prefix', prefix);


### PR DESCRIPTION
Allows users with permission level 0 to check the prefix. Still requires permission level 6 to change the prefix.