### PR TITLE
Improve exec.js

### DIFF
--- a/commands/System/exec.js
+++ b/commands/System/exec.js
@@ -9,17 +9,20 @@ module.exports = class extends Command {
 			description: 'Execute commands in the terminal, use with EXTREME CAUTION.',
 			guarded: true,
 			permissionLevel: 10,
-			usage: '<expression:string>'
+			usage: '<expression:string>',
+			extendedHelp: 'Times out in 60 seconds by default. This can be changed with --timeout=TIME_IN_MILLISECONDS'
 		});
 	}
 
 	async run(msg, [input]) {
+		await msg.sendMessage('Executing your command...');
+
 		const result = await exec(input, { timeout: 'timeout' in msg.flags ? Number(msg.flags.timeout) : 60000 })
 			.catch(error => ({ stdout: null, stderr: error }));
 		const output = result.stdout ? `**\`OUTPUT\`**${codeBlock('prolog', result.stdout)}` : '';
 		const outerr = result.stderr ? `**\`ERROR\`**${codeBlock('prolog', result.stderr)}` : '';
 
-		return msg.sendMessage([output, outerr].join('\n'));
+		return msg.sendMessage([output, outerr].join('\n') || 'Done. There was no output to stdout or stderr.');
 	}
 
 };


### PR DESCRIPTION
- Added extendedHelp explaining the `--timeout` flag
- Added loading message, so the user knows the bot heard them (I just send a message directly, not using the sendLoading extendable, but it should work the same)
- Added a default message when done, in case there was no output to stdout or stderr, to prevent a DAPI error