### PR TITLE
modified mongo provider to accept a connection string

### DIFF
--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -18,9 +18,7 @@ module.exports = class extends Provider {
 		}, this.client.options.providers.mongodb);
 
 		// If full connection string is provided, use that, otherwise fall back to individual parameters
-		const connectionString = this.client.options.providers.mongodb.connectionString ?
-			this.client.options.providers.mongodb.connectionString :
-			`mongodb://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.db}`;
+		const connectionString = this.client.options.providers.mongodb.connectionString || `mongodb://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.db}`;
 
 		const mongoClient = await Mongo.connect(
 			connectionString,

--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -16,9 +16,17 @@ module.exports = class extends Provider {
 			db: 'klasa',
 			options: {}
 		}, this.client.options.providers.mongodb);
+
+		// If full connection string is provided, use that, otherwise fall back to individual parameters
+		const connectionString = this.client.options.providers.mongodb.connectionString ?
+			this.client.options.providers.mongodb.connectionString :
+			`mongodb://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.db}`;
+
 		const mongoClient = await Mongo.connect(
-			`mongodb://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.db}`,
-			mergeObjects(connection.options, { useNewUrlParser: true }));
+			connectionString,
+			mergeObjects(connection.options, { useNewUrlParser: true })
+		);
+
 		this.db = mongoClient.db(connection.db);
 	}
 


### PR DESCRIPTION
This PR modifies the mongo provider to accept a connection string, for example:
`mongodb+srv://<username>:<password>@cluster0-123abc.mongodb.net/`
would work