### PR TITLE
Count() For RethinkDB

### DIFF
--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -47,7 +47,7 @@ module.exports = class extends Provider {
 	sync(table) {
 		return this.db.table(table).sync().run();
 	}
-	
+
 	count(table) {
 		return this.db.table(table).count().run();
 	}

--- a/providers/rethinkdb.js
+++ b/providers/rethinkdb.js
@@ -47,6 +47,10 @@ module.exports = class extends Provider {
 	sync(table) {
 		return this.db.table(table).sync().run();
 	}
+	
+	count(table) {
+		return this.db.table(table).count().run();
+	}
 
 	/* Document methods */
 


### PR DESCRIPTION
This PR adds in the functionality to get the amount of documents in a table for the RDB provider.

```js
this.client.providers.default.count('TABLENAME')
```

Use Cases:

```js
const table = await this.client.providers.default.getAll('TABLENAME')
if (!table.length) return null
```

Having to fetch every single document in a table just to check if it has any documents isnt ideal. This is where the count comes in. 

Hope it helps.  Thanks Jacz