### PR TITLE
fix everything of undefined bug

### DIFF
--- a/tasks/reloadOnChanges.js
+++ b/tasks/reloadOnChanges.js
@@ -33,7 +33,7 @@ module.exports = class extends Task {
 		}
 
 		timer.stop();
-		return this.client.emit('log', `${name} was updated. ${log}`);
+		this.client.emit('log', `${name} was updated. ${log}`);
 	}
 
 	async init() {

--- a/tasks/reloadOnChanges.js
+++ b/tasks/reloadOnChanges.js
@@ -49,13 +49,19 @@ module.exports = class extends Task {
 			cwd: process.cwd()
 		});
 
-		const reloadStore = (_path) => {
+		const reloadStore = async (_path) => {
 			const store = _path.split(sep)
 				.find(dir => this.client.pieceStores.has(dir));
 
 			const name = basename(_path);
 
-			if (!store) return this.run(name, _path);
+			if (!store) {
+				if (this._running) return;
+				this._running = true;
+				await this.run(name, _path);
+				this._running = false;
+				return;
+			}
 
 			const piece = this.client.pieceStores.get(store)
 				.get(name.replace(extname(name), ''));

--- a/tasks/reloadOnChanges.js
+++ b/tasks/reloadOnChanges.js
@@ -66,7 +66,7 @@ module.exports = class extends Task {
 			const piece = this.client.pieceStores.get(store)
 				.get(name.replace(extname(name), ''));
 
-			return this.run(name, _path, piece);
+			this.run(name, _path, piece);
 		};
 
 		for (const event of ['add', 'change', 'unlink']) {


### PR DESCRIPTION
Closes #210 

The cause of the bug is when the task tries to reload everything several times at an instant (e.g., change several non-piece files at once by moving/deleting/adding them). Whilst it is still reloading everything, and the piece stores have been emptied, it tries to reload several times again, hence the `reload` command not existing.