### PR TITLE
fix: Resolved DeprecationWarning from MongoDB Provider

### DIFF
--- a/providers/mongodb.js
+++ b/providers/mongodb.js
@@ -22,7 +22,7 @@ module.exports = class extends Provider {
 
 		const mongoClient = await Mongo.connect(
 			connectionString,
-			mergeObjects(connection.options, { useNewUrlParser: true })
+			mergeObjects(connection.options, { useNewUrlParser: true, useUnifiedTopology: true })
 		);
 
 		this.db = mongoClient.db(connection.db);


### PR DESCRIPTION
gets rid of the error below
```(node:18596) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.```